### PR TITLE
Conversion to Python 2/3 inter-compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ temp/
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+*.bak
 
 # Packages
 *.egg

--- a/pygchem/__init__.py
+++ b/pygchem/__init__.py
@@ -16,7 +16,14 @@ Code written by Gerrit Kuhlmann is also included in this package.
 :license: GPLv3, see LICENSE for details.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 __all__ = ["config", "globchem", "grid", "diagnostics", "io", "tools",
            "utils"]
 __version__ = '0.3.0dev'

--- a/pygchem/config.py
+++ b/pygchem/config.py
@@ -11,7 +11,14 @@
 PyGChem configuration.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import inspect
 import os
 

--- a/pygchem/dataset_backends/__init__.py
+++ b/pygchem/dataset_backends/__init__.py
@@ -12,3 +12,11 @@ Each backend should be implemented in a Python module named as follows:
 where `name` is the name of the backend or the python library used as backend.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *

--- a/pygchem/dataset_backends/backend_iris.py
+++ b/pygchem/dataset_backends/backend_iris.py
@@ -14,7 +14,17 @@ Also adds support for BPCH format to Iris.
 """
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import next
+from builtins import str
+from builtins import zip
+from builtins import range
 import glob
 import warnings
 import datetime
@@ -53,7 +63,7 @@ def _get_datablock_dim_coords(datablock, coord_cache):
     cache_fields = ('modelname', 'resolution', 'origin', 'shape')
     cache_key = '_'.join((str(datablock[f]) for f in cache_fields))
 
-    if cache_key in coord_cache.keys():
+    if cache_key in list(coord_cache.keys()):
         return coord_cache[cache_key]
 
     ctm_grid = grid.CTMGrid.from_model(datablock['modelname'],
@@ -64,7 +74,7 @@ def _get_datablock_dim_coords(datablock, coord_cache):
         shape3 = np.pad(shape, (0, len(origin) - len(shape)), 'constant')
         imin = np.array(origin) - 1
         imax = imin + np.array(shape3)
-        region_box = zip(imin, imax)
+        region_box = list(zip(imin, imax))
     else:
         region_box = None
 
@@ -252,7 +262,7 @@ def fix_bpch2nc(cube, field, filename):
         #dummy_coord = iris.coords.DimCoord([0], long_name='dummy',
         #                                   bounds=[0, 1])
         #cube.add_dim_coord(dummy_coord, 0)
-        return next(cube.slices(range(1, cube.ndim)))
+        return next(cube.slices(list(range(1, cube.ndim))))
 
 
 def fix_bpch2coards(cube, field, filename):

--- a/pygchem/dataset_backends/backend_iris.py
+++ b/pygchem/dataset_backends/backend_iris.py
@@ -252,7 +252,7 @@ def fix_bpch2nc(cube, field, filename):
         #dummy_coord = iris.coords.DimCoord([0], long_name='dummy',
         #                                   bounds=[0, 1])
         #cube.add_dim_coord(dummy_coord, 0)
-        return cube.slices(range(1, cube.ndim)).next()
+        return next(cube.slices(range(1, cube.ndim)))
 
 
 def fix_bpch2coards(cube, field, filename):
@@ -336,7 +336,7 @@ def fix_bpch2coards(cube, field, filename):
                              timeutil.time2tau(tend)]
         if cube.shape[time_dim] == 1:
             slices_dims = [d for d in range(cube.ndim) if d != time_dim]
-            return cube.slices(slices_dims).next()
+            return next(cube.slices(slices_dims))
     except iris.exceptions.CoordinateNotFoundError:
         pass
 

--- a/pygchem/datasets.py
+++ b/pygchem/datasets.py
@@ -11,7 +11,14 @@ GEOS-Chem datasets I/O using one of the available
 backends ('iris', 'netcdf', 'bpch').
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import importlib
 from contextlib import contextmanager
 

--- a/pygchem/diagnostics.py
+++ b/pygchem/diagnostics.py
@@ -11,7 +11,15 @@ GEOS-Chem diagnostics (set/get metadata to/from files 'tracerinfo.dat'
 and 'diaginfo.dat').
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
 import os
 
 from pygchem import config

--- a/pygchem/emissions.py
+++ b/pygchem/emissions.py
@@ -10,7 +10,17 @@
 Interface to the Harvard-NASA Emissions Component (HEMCO).
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import str
+from builtins import range
+from builtins import object
 import os
 
 from pygchem import config
@@ -362,7 +372,7 @@ class EmissionSetup(object):
         """
         fids = self.get_fids()
         min_fid = min(i for i in fids if i is not None)
-        range_fids = range(min_fid, max(fids) + len(fids) + 1)
+        range_fids = list(range(min_fid, max(fids) + len(fids) + 1))
         duplicate_fids = set([fid for fid in fids if fids.count(fid) > 1])
         available_fids = sorted(set(range_fids) - set(fids))
 
@@ -379,7 +389,7 @@ class EmissionSetup(object):
 
         eids = self.get_eids()
         min_eid = min(i for i in eids if i is not None)
-        range_eids = range(min_eid, max(eids) + len(eids) + 1)
+        range_eids = list(range(min_eid, max(eids) + len(eids) + 1))
         duplicate_eids = set([eid for eid in eids if eids.count(eid) > 1])
         available_eids = sorted(set(range_eids) - set(eids))
 

--- a/pygchem/globchem.py
+++ b/pygchem/globchem.py
@@ -20,7 +20,21 @@ FAST-J). The data is commonly stored in the files "globchem.dat",
 TODO: show here some examples.
 
 """
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import map
+from builtins import zip
+from builtins import str
+from builtins import range
+from past.builtins import basestring
+from past.utils import old_div
+from builtins import object
 import collections
 import types
 import numbers
@@ -120,7 +134,7 @@ class Species(object):
         if not isinstance(val, basestring):
             raise TypeError("Bad type for id: expected string, got %s"
                             % type(val).__name__)
-        if len(val) not in xrange(1, 11):
+        if len(val) not in list(range(1, 11)):
             raise ValueError("Length of id string cannot contain more than "
                              "11 characters (but at least 1 character)")
         self._id = val.upper()
@@ -136,7 +150,7 @@ class Species(object):
         if not isinstance(val, basestring):
             raise TypeError("Bad type for name: expected string, got %s"
                             % type(val).__name__)
-        if len(val) not in xrange(0, 40):
+        if len(val) not in list(range(0, 40)):
             raise ValueError("Length of name string cannot contain more than "
                              "40 characters")
         self._name = val
@@ -152,7 +166,7 @@ class Species(object):
         if not isinstance(val, basestring):
             raise TypeError("Bad type for formula: expected string, got %s"
                             % type(val).__name__)
-        if len(val) not in xrange(0, 32):
+        if len(val) not in list(range(0, 32)):
             raise ValueError("Length of name string cannot contain more than "
                              "32 characters")
         self._formula = val.upper()
@@ -169,7 +183,7 @@ class Species(object):
         if not isinstance(val, basestring):
             raise TypeError("Bad type for status: expected string, got %s"
                             % type(val).__name__)
-        if val not in self.valid_status.keys():
+        if val not in list(self.valid_status.keys()):
             raise ValueError("Bad value for status: expected one of the "
                              "following capital letters:\n%s"
                              % pprint.pformat(self.valid_status))
@@ -229,7 +243,7 @@ class Species(object):
     @mb_groups.setter
     def mb_groups(self, val):
         if (not isinstance(val, dict)
-            or not all(isinstance(v, numbers.Integral) for v in val.values())):
+            or not all(isinstance(v, numbers.Integral) for v in list(val.values()))):
             raise ValueError("mb_groups must be a dictionary with int values")
         self._mb_groups = val
 
@@ -253,11 +267,11 @@ class Species(object):
         """
         spec = cls(species_dict['id'])
         for k in cls.get_attributes():
-            if k not in species_dict.keys():
+            if k not in list(species_dict.keys()):
                 warnings.warn("species attribute '%s' not in the dictionary, "
                               "default value %s used"
                               % (k, str(getattr(spec, k))))
-        for k, v in species_dict.items():
+        for k, v in list(species_dict.items()):
             setattr(spec, k, v)
         return spec
 
@@ -265,7 +279,7 @@ class Species(object):
         """
         Return a :class:`Species` object as a python dictionary
         """
-        dict_attr_names = [k for k in self.__dict__.keys() if k[0] != '_']
+        dict_attr_names = [k for k in list(self.__dict__.keys()) if k[0] != '_']
         attr_names = set(dict_attr_names + self.get_attributes())
 
         return {k: getattr(self, k) for k in attr_names}
@@ -276,7 +290,7 @@ class Species(object):
         Return a list of the names of the :class:`Species` built-in attributes 
         (i.e., properties). 
         """
-        return [k for k, v in cls.__dict__.items() if type(v) == property]
+        return [k for k, v in list(cls.__dict__.items()) if type(v) == property]
 
 
 class ReactionRate(object):
@@ -344,10 +358,10 @@ class ReactionRate(object):
 
         info = {'flag': flags, 'function': functions, 'fname': fnames,
                 'descr': descr}
-        if key not in info.keys() or val not in info.keys():
+        if key not in list(info.keys()) or val not in list(info.keys()):
             raise ValueError("invalid argument(s) key and/or val")
 
-        return dict(zip(info[key], info[val]))
+        return dict(list(zip(info[key], info[val])))
 
     @classmethod
     def get_ratef_fromflag(cls, flag):
@@ -387,7 +401,7 @@ class ReactionRate(object):
         arr : list of 3 floats
             parameters [A,B,C] of the rate constant expression
         """
-        return arr[0] * (300 / T) ** arr[1] * np.exp(arr[2] / T)
+        return arr[0] * (old_div(300, T)) ** arr[1] * np.exp(old_div(arr[2], T))
 
     @classmethod
     def p_ratek(cls, T, cM, arrlow=[0., 0., 0.], arrhigh=[0., 0., 0.],
@@ -437,15 +451,15 @@ class ReactionRate(object):
         Pr = K0 * cM / Kinf
 
         if falloff[2] != 0.:
-            Fc = math.exp(-T / falloff[1]) + math.exp(-falloff[2] / T)
+            Fc = math.exp(old_div(-T, falloff[1])) + math.exp(old_div(-falloff[2], T))
         elif falloff[1] != 0.:
-            Fc = math.exp(-T / falloff[1])
+            Fc = math.exp(old_div(-T, falloff[1]))
         else:
             Fc = falloff[0]
 
-        F = Fc ** (1. / (1. + math.log10(Pr) ** 2))
+        F = Fc ** (old_div(1., (1. + math.log10(Pr) ** 2)))
 
-        K = Kinf * (Pr / (1. + Pr)) * F
+        K = Kinf * (old_div(Pr, (1. + Pr))) * F
 
         return K
 
@@ -483,7 +497,7 @@ class ReactionRate(object):
             direction)
         """
         Kf = cls.p_ratek(T, cM, f_arrlow, f_arrhigh, f_falloff)
-        return Kf / cls.arr_ratek(T, arr)
+        return old_div(Kf, cls.arr_ratek(T, arr))
 
     @classmethod
     def x_ratek(cls, T, cM, arrK0=[0., 0., 0.], arrK2=[0., 0., 0.],
@@ -571,7 +585,7 @@ class ReactionRate(object):
         """
         K1 = cls.arr_ratek(T, arrK1)
         K2 = cls.arr_ratek(T, arrK2)
-        K = (K1 + K2 * cM) * (1. + 1.4e-21 * cH2O * math.exp(2200. / T))
+        K = (K1 + K2 * cM) * (1. + 1.4e-21 * cH2O * math.exp(old_div(2200., T)))
 
     @classmethod
     def a_ratek(cls, T, cM, arrK1=[0., 0., 0.], xcarbon=0.):
@@ -697,7 +711,7 @@ class ReactionRate(object):
         """
         K1 = cls.arr_ratek(T, arrK1)
         K2 = cls.arr_ratek(T, arrK2)
-        return K1 / (1. + K2)
+        return old_div(K1, (1. + K2))
 
     @classmethod
     def g_ratek(cls, T, cO2, arrK1, arrK2):
@@ -723,7 +737,7 @@ class ReactionRate(object):
         """
         K1 = cls.arr_ratek(T, arrK1)
         K2 = cls.arr_ratek(T, arrK2)
-        return K1 / (1. + K2 * cO2)
+        return old_div(K1, (1. + K2 * cO2))
 
     # TODO: built-in function for HOC2H4O ------> HO2 + 2CH2O  (see calcrate.f)
 
@@ -753,12 +767,12 @@ class ReactionRate(object):
         xminf = 8.1
         xf = 0.411
 
-        xxyn = alpha * math.exp(beta * xcarbn) * zdnum * ((300. / T) ** xm0)
-        yyyn = y300 * ((300. / T) ** xminf)
-        aaa = math.log10(xxyn / yyyn)
-        zzyn = 1. / (1. + aaa * aaa)
-        rarb = (xxyn / (1. + (xxyn / yyyn))) * (xf ** zzyn)
-        fyrno3 = rarb / (1. + rarb)
+        xxyn = alpha * math.exp(beta * xcarbn) * zdnum * ((old_div(300., T)) ** xm0)
+        yyyn = y300 * ((old_div(300., T)) ** xminf)
+        aaa = math.log10(old_div(xxyn, yyyn))
+        zzyn = old_div(1., (1. + aaa * aaa))
+        rarb = (old_div(xxyn, (1. + (old_div(xxyn, yyyn))))) * (xf ** zzyn)
+        fyrno3 = old_div(rarb, (1. + rarb))
 
         return fyrno3
 
@@ -916,7 +930,7 @@ class Reaction(object):
         if not isinstance(val, basestring):
             raise TypeError("Bad type for status: expected string, got %s"
                             % type(val).__name__)
-        if val not in self.valid_status.keys():
+        if val not in list(self.valid_status.keys()):
             raise ValueError("Bad value for status: expected one of the "
                              "following capital letters:\n%s"
                              % pprint.pformat(self.valid_status))
@@ -959,12 +973,12 @@ class Reaction(object):
         """
         reac = cls(reac_dict['id'])
         for k in cls.get_attributes():
-            if k not in reac_dict.keys():
+            if k not in list(reac_dict.keys()):
                 warnings.warn("reaction attribute '%s' not in the dictionary, "
                               "default value %s used"
                               % (k, str(getattr(reac, k))))
         reac.flag = reac_dict['flag']   # must be set before rate
-        for k, v in reac_dict.items():
+        for k, v in list(reac_dict.items()):
             setattr(reac, k, v)
         return reac
 
@@ -972,7 +986,7 @@ class Reaction(object):
         """
         Return a :class:`Reaction` object as a python dictionary
         """
-        dict_attr_names = [k for k in self.__dict__.keys() if k[0] != '_']
+        dict_attr_names = [k for k in list(self.__dict__.keys()) if k[0] != '_']
         attr_names = set(dict_attr_names + self.get_attributes())
 
         return {k: getattr(self, k) for k in attr_names}
@@ -983,7 +997,7 @@ class Reaction(object):
         Return a list of the names of the :class:`Reaction` built-in attributes 
         (i.e., properties). 
         """
-        return [k for k, v in cls.__dict__.items() if type(v) == property]
+        return [k for k, v in list(cls.__dict__.items()) if type(v) == property]
 
     def format(self):
         """
@@ -1095,7 +1109,7 @@ class Globchem(object):
         value : int
             default value to assign to each species
         """
-        if group_id in self.mb_groups.keys():
+        if group_id in list(self.mb_groups.keys()):
             raise KeyError("group_id already in mass balance groups")
         if status not in ('A', 'D'):
             raise ValueError("Bad value for status")
@@ -1104,7 +1118,7 @@ class Globchem(object):
 
         self.mb_groups[group_id] = status
 
-        for s in self.species.values():
+        for s in list(self.species.values()):
             s.mb_groups[group_id] = value
 
     def remove_mb_group(self, group_id):
@@ -1116,17 +1130,17 @@ class Globchem(object):
         group_id : string
             mass blance group identifiant
         """
-        if group_id not in self.mb_groups.keys():
+        if group_id not in list(self.mb_groups.keys()):
             raise KeyError("no mass balance group with group_id")
         del self.mb_groups[group_id]
-        for s in self.species.values():
+        for s in list(self.species.values()):
             del s.mb_groups[group_id]
 
     def filter_mb_groups_bystatus(self, status):
         """
         Return a id list with mass balance groups of 'status'   
         """
-        return [k for k, v in self.mb_groups.items() if v == status]
+        return [k for k, v in list(self.mb_groups.items()) if v == status]
 
     def add_species(self, spec):
         """
@@ -1140,7 +1154,7 @@ class Globchem(object):
         def add_one_species(spec1):
             if not isinstance(spec1, Species):
                 raise TypeError("argument is not a Species object")
-            elif spec1.id in self.species.keys():
+            elif spec1.id in list(self.species.keys()):
                 raise KeyError("species with key %s already exists in Globchem"
                            % spec1.id)
             self.species[spec1.id] = spec1
@@ -1173,7 +1187,7 @@ class Globchem(object):
             # update reactions
             for rt, rs in [[self.reac_kn, "kinetic"],
                            [self.reac_ph, "photolysis"]]:
-                reac_list = [k for k, v in rt.items()
+                reac_list = [k for k, v in list(rt.items())
                              if spec1_id in v.reactants
                              or spec1_id in v.products]
                 self.remove_reaction(reac_list, rs)
@@ -1211,13 +1225,13 @@ class Globchem(object):
             new species
         """
         def copy_one_species(spec1_id, new1_id, **kwargs):
-            if spec1_id not in self.species.keys():
+            if spec1_id not in list(self.species.keys()):
                 raise KeyError("Species %s doesn't exist" % spec1_id)
 
             new_spec = copy.deepcopy(self.species[spec1_id])
             new_spec.id = new1_id
-            for k, v in kwargs.items():
-                if k not in new_spec.to_dict().keys():
+            for k, v in list(kwargs.items()):
+                if k not in list(new_spec.to_dict().keys()):
                     raise KeyError("Invalid Species property : %s" % k)
                 setattr(new_spec, k, v)
 
@@ -1226,9 +1240,9 @@ class Globchem(object):
             # update reactions
             for rt, rs in [[self.reac_kn, "kinetic"],
                            [self.reac_ph, "photolysis"]]:
-                reac_list1 = [k for k, v in rt.items()
+                reac_list1 = [k for k, v in list(rt.items())
                               if spec1_id in v.reactants]
-                reac_list2 = [k for k, v in rt.items()
+                reac_list2 = [k for k, v in list(rt.items())
                               if spec1_id in v.products]
                 for k in reac_list1:
                     new_id = k + 0.5
@@ -1244,11 +1258,11 @@ class Globchem(object):
 
         if hasattr(new_id, "__iter__") and not isinstance(new_id, dict):
             # verify and re-arrange kwargs
-            for k, listv in kwargs.items():
+            for k, listv in list(kwargs.items()):
                 if len(listv) != len(new_id):
                     raise ValueError("Invalid value for kwarg '%s'" % k)
-            tp = zip(*([(k, v) for v in listv] for k, listv in kwargs.items()))
-            list_kwargs = map(dict, tp)
+            tp = list(zip(*([(k, v) for v in listv] for k, listv in list(kwargs.items()))))
+            list_kwargs = list(map(dict, tp))
 
             if len(list_kwargs) > 0:
                 for s, kw in zip(new_id, list_kwargs):
@@ -1292,9 +1306,9 @@ class Globchem(object):
         str_fexpr = "fexpr(" + str_list_attr + ")"
 
         if getid:
-            return [id for id, s in self.species.items() if eval(str_fexpr)]
+            return [id for id, s in list(self.species.items()) if eval(str_fexpr)]
         else:
-            return [s for s in self.species.values() if eval(str_fexpr)]
+            return [s for s in list(self.species.values()) if eval(str_fexpr)]
 
     def add_reaction(self, reac, reorder=True):
         """
@@ -1314,13 +1328,13 @@ class Globchem(object):
         """
         def add_one_reaction(reac1):
             if isinstance(reac1, (PhotolysisReaction)):
-                if reac1.id in self.reac_ph.keys():
+                if reac1.id in list(self.reac_ph.keys()):
                     raise KeyError("photolysis reaction with id/key %s already"
                                    " exists in Globchem" % reac1.id)
                 else:
                     self.reac_ph[reac1.id] = reac1
             elif isinstance(reac1, (Reaction, KineticReaction)):
-                if reac1.id in self.reac_kn.keys():
+                if reac1.id in list(self.reac_kn.keys()):
                     raise KeyError("kinetic reaction with id/key %s already "
                                    "exists in Globchem" % reac1.id)
                 else:
@@ -1401,13 +1415,13 @@ class Globchem(object):
             new reaction
         """
         def copy_one_reaction(reac1_id, new1_id, rt, reorder, **kwargs):
-            if reac1_id not in rt.keys():
+            if reac1_id not in list(rt.keys()):
                 raise KeyError("Reaction %s doesn't exist" % spec1_id)
 
             new_reac = copy.deepcopy(rt[reac1_id])
             new_reac.id = new1_id
-            for k, v in kwargs.items():
-                if k not in new_reac.to_dict().keys():
+            for k, v in list(kwargs.items()):
+                if k not in list(new_reac.to_dict().keys()):
                     raise KeyError("Invalid Reaction property : %s" % k)
                 setattr(new_reac, k, v)
 
@@ -1420,11 +1434,11 @@ class Globchem(object):
 
         if hasattr(new_id, "__iter__") and not isinstance(new_id, dict):
             # verify and re-arrange kwargs
-            for k, listv in kwargs.items():
+            for k, listv in list(kwargs.items()):
                 if len(listv) != len(new_id):
                     raise ValueError("Invalid value for kwarg '%s'" % k)
-            tp = zip(*([(k, v) for v in listv] for k, listv in kwargs.items()))
-            list_kwargs = map(dict, tp)
+            tp = list(zip(*([(k, v) for v in listv] for k, listv in list(kwargs.items()))))
+            list_kwargs = list(map(dict, tp))
 
             if len(list_kwargs) > 0:
                 for r, kw in zip(new_id, list_kwargs):
@@ -1473,9 +1487,9 @@ class Globchem(object):
             rt = self.reac_ph
 
         if getid:
-            return [id for id, s in rt.items() if eval(str_fexpr)]
+            return [id for id, s in list(rt.items()) if eval(str_fexpr)]
         else:
-            return [s for s in rt.values() if eval(str_fexpr)]
+            return [s for s in list(rt.values()) if eval(str_fexpr)]
 
     def _reorder_reactions(self):
         """
@@ -1515,11 +1529,11 @@ class Globchem(object):
         gc.filename_dat = filename
         gc.description = header
         gc.mb_groups = mb_groups
-        gc.add_species((Species.from_dict(s) for s in species.values()))
+        gc.add_species((Species.from_dict(s) for s in list(species.values())))
         gc.add_reaction((KineticReaction.from_dict(rkn)
-                         for rkn in reac_kn.values()))
+                         for rkn in list(reac_kn.values())))
         gc.add_reaction((PhotolysisReaction.from_dict(rph)
-                         for rph in reac_ph.values()))
+                         for rph in list(reac_ph.values())))
 
         # TODO: add photolysis reactions
 

--- a/pygchem/globchem.py
+++ b/pygchem/globchem.py
@@ -894,7 +894,7 @@ class Reaction(object):
         return self._rate
     @rate.setter
     def rate(self, val):
-        if isinstance(val, (ReactionRate, types.NoneType)):
+        if isinstance(val, (ReactionRate, type(None))):
             self._rate = val
         elif isinstance(val, dict):
             ratef = ReactionRate.get_ratef_fromflag(self.flag)

--- a/pygchem/grid.py
+++ b/pygchem/grid.py
@@ -18,7 +18,17 @@ It provides default grid specification for various models and allows to easily
 get grid coordinates. User-specific grids can also be defined.
 
 """
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import hex
+from builtins import object
+from past.utils import old_div
 import numpy as np
 
 from pygchem.tools import atm, gridspec
@@ -116,7 +126,7 @@ class CTMGrid(object):
         self._altitude_edges = None
         self._altitude_centers = None
 
-        for k, v in kwargs.items():
+        for k, v in list(kwargs.items()):
             self.__setattr__(k, v)
 
     @classmethod
@@ -153,7 +163,7 @@ class CTMGrid(object):
         """
         settings = gridspec.get_model_info(model_name)
         model = settings.pop('model_name')
-        for k, v in kwargs.items():
+        for k, v in list(kwargs.items()):
             if k in ('resolution', 'Psurf'):
                 settings[k] = v
 
@@ -235,8 +245,8 @@ class CTMGrid(object):
         rlon = self.resolution[0]
         rlat = self.resolution[1]
 
-        Nlon = int(360. / rlon)
-        Nlat = int(180. / rlat) + self.halfpolar
+        Nlon = int(old_div(360., rlon))
+        Nlat = int(old_div(180., rlat)) + self.halfpolar
 
         elon = np.arange(Nlon + 1) * rlon - np.array(180.)
         elon -= rlon / 2. * self.center180
@@ -245,14 +255,14 @@ class CTMGrid(object):
         elat[0] = -90.
         elat[-1] = 90.
 
-        clon = (elon - rlon / 2.)[1:]
+        clon = (elon - old_div(rlon, 2.))[1:]
         clat = np.arange(Nlat) * rlat - np.array(90.)
 
         if self.halfpolar:                        # Fix grid boundaries
-            clat[0] = (elat[0] + elat[1]) / 2.
+            clat[0] = old_div((elat[0] + elat[1]), 2.)
             clat[-1] = - clat[0]
         else:
-            clat += (elat[1] - elat[0]) / 2.
+            clat += old_div((elat[1] - elat[0]), 2.)
 
         self._lonlat_centers = (clon, clat)
         self._lonlat_edges = (elon, elat)
@@ -546,8 +556,8 @@ class CTMGrid(object):
         Pc = 0.5 * (Pe[0:-1] + Pe[1:])
 
         if self.hybrid:
-            ETAe = (Pe - Ptop) / (Psurf - Ptop)
-            ETAc = (Pc - Ptop) / (Psurf - Ptop)
+            ETAe = old_div((Pe - Ptop), (Psurf - Ptop))
+            ETAc = old_div((Pc - Ptop), (Psurf - Ptop))
         else:
             SIGe = SIGe * np.ones_like(Psurf)
             SIGc = SIGc * np.ones_like(Psurf)

--- a/pygchem/io/__init__.py
+++ b/pygchem/io/__init__.py
@@ -11,5 +11,12 @@ Read/write GEOS-Chem files (input or output) into/from Python built-in
 data structures.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 __all__ = ["globchem", "bpch", "diaginfo"]

--- a/pygchem/io/bpch.py
+++ b/pygchem/io/bpch.py
@@ -10,7 +10,16 @@
 Read / write binary punch (BPCH) files.
 
 """
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from past.utils import old_div
+from builtins import object
 import os
 
 import numpy as np
@@ -74,7 +83,7 @@ class BPCHDataProxy(object):
         return {attr: getattr(self, attr) for attr in self.__slots__}
 
     def __setstate__(self, state):
-        for key, value in state.iteritems():
+        for key, value in list(state.items()):
             setattr(self, key, value)
 
 
@@ -247,7 +256,7 @@ def append_bpch(bpch_file, datablock):
 
     """
     if isinstance(datablock['data'], BPCHDataProxy):
-        data = datablock['data'].data / datablock['data'].scale_factor
+        data = old_div(datablock['data'].data, datablock['data'].scale_factor)
     else:
         data = datablock['data']
 

--- a/pygchem/io/bpch.py
+++ b/pygchem/io/bpch.py
@@ -159,6 +159,10 @@ def read_bpch(filename, mode='rb', skip_data=True,
             category_name, number, unit, tau0, tau1, reserved = line[:6]
             dim0, dim1, dim2, dim3, dim4, dim5, skip = line[6:]
 
+            # Decode byte-strings to utf-8
+            category_name = str(category_name, 'utf-8')
+            unit = str(unit, 'utf-8')
+
             # get additional metadata from tracerinfo / diaginfo
             try:
                 cat = ctm_info.categories.select_item(category_name.strip())

--- a/pygchem/io/diaginfo.py
+++ b/pygchem/io/diaginfo.py
@@ -11,7 +11,14 @@ Read / write 'diaginfo.dat' and 'tracerinfo.dat' files (GEOS-Chem diagnostics
 metadata).
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from pygchem.utils.tff import read_fmt_file, write_fmt_file
 
 DIAGINFO_FMT = (

--- a/pygchem/io/globchem.py
+++ b/pygchem/io/globchem.py
@@ -22,7 +22,19 @@ defined in the :module:`pygchem.glochem` module.
 
 External dependencies: fortranformat, sqlite3
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import filter
+from builtins import str
+from builtins import zip
+from builtins import range
+from past.builtins import basestring
 import os
 import collections
 
@@ -102,7 +114,7 @@ def read_globchem_dat(filename):
         species_item['init_concentration'] = [float(i) for i in
                                             species_item['init_concentration']]
         mb_vals = [int(i) for i in species_item['mb_groups']]
-        species_item['mb_groups'] = dict(zip(mb_groups.keys(), mb_vals))
+        species_item['mb_groups'] = dict(list(zip(list(mb_groups.keys()), mb_vals)))
 
     def trim_rlist(reac_list):
         """
@@ -111,7 +123,7 @@ def read_globchem_dat(filename):
         """
         # filter below permits to take only items that are not '' (if string)
         # or 0 (if int or float) because bool('') and bool(0) both return False
-        return filter(bool, reac_list)
+        return list(filter(bool, reac_list))
 
     def read_reac(globchem_file, fline):
         """
@@ -179,8 +191,8 @@ def read_globchem_dat(filename):
 
         # read reaction rate parameters
         n_addrates = reac_row1.pop(5)
-        reac_rates = dict(zip(reac_rates_keys,
-                              reac_row1[2:5] + reac_row1[6:9]))
+        reac_rates = dict(list(zip(reac_rates_keys,
+                              reac_row1[2:5] + reac_row1[6:9])))
         if(n_addrates > 0):
             for i in range(0, n_addrates):
                 new_keys = [s + str(i + 1) for s in reac_rates_keys]
@@ -188,13 +200,13 @@ def read_globchem_dat(filename):
                 fline += 1
                 reac_row2 = reac_r2_fmt.read(l_globchem)
                 del reac_row2[3]  # remove slot for number of rate coef lines
-                reac_rates.update(dict(zip(new_keys, reac_row2)))
+                reac_rates.update(dict(list(zip(new_keys, reac_row2))))
 
         # re-arrange rate parameters using corr_ratep
         reac_flag = reac_item[3].upper()
         mod_reac_rates = dict()
         if reac_flag in mod_ratep:
-            for k, v in mod_ratep[reac_flag].items():
+            for k, v in list(mod_ratep[reac_flag].items()):
                 if (isinstance(v, collections.Iterable)
                     and not isinstance(v, basestring)):
                     mod_reac_rates[k] = [reac_rates[n] for n in v]
@@ -216,8 +228,8 @@ def read_globchem_dat(filename):
         if(reac_eq[-2] is None):
             reac_eq[-2] = 0.0
 
-        reac_item.append(trim_rlist([reac_eq[i] for i in xrange(1, 13, 3)]))
-        reac_item.append(trim_rlist([reac_eq[i] for i in xrange(13, 61, 3)]))
+        reac_item.append(trim_rlist([reac_eq[i] for i in range(1, 13, 3)]))
+        reac_item.append(trim_rlist([reac_eq[i] for i in range(13, 61, 3)]))
         reac_item.append(trim_rlist([reac_eq[i] for i in range(12, 60, 3)]))
 
         return reac_item
@@ -236,7 +248,7 @@ def read_globchem_dat(filename):
         row = [s.strip() for s in row]
         species_info[row[0]] = row[1:]
     f_species_dat.close()
-    species_info_blank = ['' for s in xrange(0, len(species_info.keys()[0]))]
+    species_info_blank = ['' for s in range(0, len(list(species_info.keys())[0]))]
 
     # globchem.dat file
     globchem_file = open(filename, "r")
@@ -258,7 +270,7 @@ def read_globchem_dat(filename):
     l_globchem = globchem_file.readline()
     mb_st = sanatize_str_inlist(species_mb_st_fmt.read(l_globchem))
 
-    mb_groups = dict(zip(mb_id, mb_st))
+    mb_groups = dict(list(zip(mb_id, mb_st)))
     fline += 2
 
     species_r1_fmt = FortranRecordReader('(A1,1X,A14,A2,1X,0PF6.2,4(1PE10.3))')
@@ -278,7 +290,7 @@ def read_globchem_dat(filename):
         except KeyError:
             species_vals += species_info_blank
 
-        species[species_this_key] = dict(zip(species_keys, species_vals))
+        species[species_this_key] = dict(list(zip(species_keys, species_vals)))
         convert_species_item(species[species_this_key], mb_groups)
         del species_vals
         n_species += 1
@@ -301,7 +313,7 @@ def read_globchem_dat(filename):
             elif reac_flag == 'E':
                 reac_vals[5].update(mem_p_ratep)
 
-            reac_kn[n_reac] = dict(zip(reac_keys, reac_vals))
+            reac_kn[n_reac] = dict(list(zip(reac_keys, reac_vals)))
             reac_kn[n_reac]['id'] = n_reac
             n_reac += 1
         del reac_vals
@@ -313,14 +325,14 @@ def read_globchem_dat(filename):
         if(reac_vals == "end"):
             break
         else:
-            reac_ph[n_reac] = dict(zip(reac_keys, reac_vals))
+            reac_ph[n_reac] = dict(list(zip(reac_keys, reac_vals)))
             reac_ph[n_reac]['id'] = n_reac
             n_reac += 1
         del reac_vals
 
     # identify links between species (through reactions): parse reac_kn
     link_id = 0
-    for reac_key, reac_vals in reac_kn.iteritems():
+    for reac_key, reac_vals in list(reac_kn.items()):
         for reactant in reac_vals['reactants']:
             if(reactant != '' and reactant != 'M'):
                 for product in reac_vals['products']:

--- a/pygchem/io/hemco.py
+++ b/pygchem/io/hemco.py
@@ -10,7 +10,16 @@
 Read / Write Harvard-NASA Emissions Component (HEMCO) settings files.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import zip
+from builtins import str
 import re
 import itertools
 from types import StringTypes
@@ -156,7 +165,7 @@ def _get_sections_lines(filename):
                 continue
             if 'BEGIN SECTION' in line:
                 section = line.replace('BEGIN SECTION ', '')
-                if not section in lines.keys():
+                if not section in list(lines.keys()):
                     lines[section] = []
                 continue
             if 'END SECTION' in line:

--- a/pygchem/tools/__init__.py
+++ b/pygchem/tools/__init__.py
@@ -14,5 +14,12 @@ This acts as a toolbox gathering miscellaneous functions organized in several
 modules depending on their usage or their external dependencies.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 __all__ = ['atm', 'ctm2cf', 'gridspec', 'irisutil', 'timeutil']

--- a/pygchem/tools/atm.py
+++ b/pygchem/tools/atm.py
@@ -15,8 +15,15 @@
 This module contains routines related to atmospheric science.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import numpy as np
 
 

--- a/pygchem/tools/ctm2cf.py
+++ b/pygchem/tools/ctm2cf.py
@@ -40,12 +40,12 @@ UNITS_MAP_CTM2CF = (
     ('atoms C', 'count'),
     ('ppbC', 'ppb'),        # prefix or suffix required (nb. of carbon atoms)
     ('kg C', 'kg'),         # prefix or suffix required (?)
-    ('molC', 'mol'),        # prefix or suffix required ?     TODO: 
+    ('molC', 'mol'),        # prefix or suffix required ?     TODO:
     ('gC', 'g'),            # prefix or suffix required ?
     ('kg S', 'kg'),
     ('kg OH', 'kg'),
     ('kg NO3', 'kg'),
-    ('kg H2O2', 'kg'), 
+    ('kg H2O2', 'kg'),
     ('unitless', '1'),
     ('unitles', '1'),       # typo found in tracerinfo or diaginfo
     ('v/v', '1'),
@@ -60,14 +60,14 @@ UNITS_MAP_CTM2CF = (
     ('deg C', 'Celsius'),
     ('C', 'Celsius'),
     ('mm/da', 'mm/day'),    # typo in tracerinfo.dat 4/17/12
-    ('kg/m2/', 'kg/m2'))    # ?? (tracerinfo.dat 6801 (line 1075)             
+    ('kg/m2/', 'kg/m2'))    # ?? (tracerinfo.dat 6801 (line 1075)
 
 
 def get_cfcompliant_units(units, prefix='', suffix=''):
     """
     Get equivalent units that are compatible with the udunits2 library
     (thus CF-compliant).
-    
+
     Parameters
     ----------
     units : string
@@ -78,21 +78,21 @@ def get_cfcompliant_units(units, prefix='', suffix=''):
     suffix : string
         Will be added at the end of the returned string
         (must be a valid udunits2 expression).
-    
+
     Returns
     -------
     A string representation of the conforming units.
-    
+
     References
     ----------
     The udunits2 package : http://www.unidata.ucar.edu/software/udunits/
-    
+
     Notes
     -----
     This function only relies on the table stored in :attr:`UNITS_MAP_CTM2CF`.
     Therefore, the units string returned by this function is not certified to
     be compatible with udunits2.
-    
+
     Examples
     --------
     >>> get_cfcompliant_units('molec/cm2')
@@ -101,13 +101,13 @@ def get_cfcompliant_units(units, prefix='', suffix=''):
     '1'
     >>> get_cfcompliant_units('ppbC', prefix='3')
     '3ppb
-    
+
     """
     compliant_units = units
-    
+
     for gcunits, udunits in UNITS_MAP_CTM2CF:
-        compliant_units = string.replace(compliant_units, gcunits, udunits)
-    
+        compliant_units = str.replace(compliant_units, gcunits, udunits)
+
     return prefix + compliant_units + suffix
 
 

--- a/pygchem/tools/ctm2cf.py
+++ b/pygchem/tools/ctm2cf.py
@@ -16,7 +16,14 @@ References:
     December, 2011.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import string
 
 from pygchem.tools import timeutil

--- a/pygchem/tools/gridspec.py
+++ b/pygchem/tools/gridspec.py
@@ -33,7 +33,15 @@ See Also
     provides a more complete API for handling grids used by GEOS-Chem.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import zip
 import re
 import itertools
 
@@ -543,11 +551,10 @@ def get_model_info(model_name):
     gen_seps = itertools.combinations_with_replacement(
         sep_chars, len(split_name) - 1
     )
-    test_names = ("".join((n for n in itertools.chain(*zip(split_name,
-                                                           s + ('',)))))
+    test_names = ("".join((n for n in itertools.chain(*list(zip(split_name,
+                                                           s + ('',))))))
                   for s in gen_seps)
-    match_names = list(filter(lambda name: name in get_supported_models(),
-                              test_names))
+    match_names = list([name for name in test_names if name in get_supported_models()])
 
     if not len(match_names):
         raise ValueError("Model '{0}' is not supported".format(model_name))

--- a/pygchem/tools/irisutil.py
+++ b/pygchem/tools/irisutil.py
@@ -10,7 +10,16 @@
 A bunch of utility functions based on the SciTools's Iris package.
 
 """
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import range
+from past.utils import old_div
 import collections
 import warnings
 from types import StringTypes
@@ -365,7 +374,7 @@ def fix_cube_attributes_vals(cube):
 
     Convert it to int.
     """
-    for key, val in cube.attributes.items():
+    for key, val in list(cube.attributes.items()):
         if type(val) == bool:
             cube.attributes[key] = int(val)
 
@@ -434,7 +443,7 @@ def ppbC_2_ppbv(cube):
 
     if is_hydrocarbon and is_ppbc:
         carbon_weight = cube.attributes.get('carbon_weight')
-        cube.data = cube.data / carbon_weight
+        cube.data = old_div(cube.data, carbon_weight)
         cube.units = 'ppbv'
 
 
@@ -806,7 +815,7 @@ def get_altitude_coord(gridbox_heights, topography):
                      base_level_altitude)
     altitude_lbnd = altitude_ubnd - gridbox_heights.data
     altitude_lbnd[..., 1:] = altitude_ubnd[..., :-1]  # force contiguous bounds
-    altitude_points = (altitude_lbnd + altitude_ubnd) / 2.
+    altitude_points = old_div((altitude_lbnd + altitude_ubnd), 2.)
 
     altitude_bounds = np.concatenate((altitude_lbnd[..., np.newaxis],
                                       altitude_ubnd[..., np.newaxis]),
@@ -974,7 +983,7 @@ def compute_cell_volumes(cube, lon_coord='longitude', lat_coord='latitude',
                            volume,
                            long_name=v_long_name,
                            units=out_units),
-                           data_dims=range(0, height_coord.ndim))
+                           data_dims=list(range(0, height_coord.ndim)))
 
 
 def compute_tracer_columns(mixing_ratio, n_air, z_coord,
@@ -1085,7 +1094,7 @@ def _compute_exchange_vertical(src_z_coord, dst_z_coord):
     temp = np.unique(temp)
 
     exchange_z_bounds = np.column_stack((temp[:-1], temp[1:]))
-    exchange_z_points = (exchange_z_bounds[:, 0] + exchange_z_bounds[:, 1]) / 2.
+    exchange_z_points = old_div((exchange_z_bounds[:, 0] + exchange_z_bounds[:, 1]), 2.)
 
     exchange_z_coord = iris.coords.DimCoord(
         exchange_z_points,
@@ -1227,9 +1236,9 @@ def regrid_conservative_vertical(src_cube, dst_grid_cube,
     # compute interpolation weights and data values
     # on the exchange grid
     if src_data_type == 'intensive':
-        exchange_iweights = exchange_heights / dst_heights_mapped
+        exchange_iweights = old_div(exchange_heights, dst_heights_mapped)
     elif src_data_type == 'extensive':
-        exchange_iweights = exchange_heights / src_heights_mapped
+        exchange_iweights = old_div(exchange_heights, src_heights_mapped)
     else:
         raise ValueError("invalid source data type: {}"
                          .format(src_data_type))
@@ -1247,7 +1256,7 @@ def regrid_conservative_vertical(src_cube, dst_grid_cube,
     valid_heights = np.where(np.isnan(exchange_data), np.nan, exchange_heights)
     overlap_heights = np.nansum((valid_heights[np.newaxis, :] * levels_mask),
                                 axis=1)
-    overlap_heights_relative = overlap_heights / dst_heights
+    overlap_heights_relative = old_div(overlap_heights, dst_heights)
     nan_indices = np.nonzero(overlap_heights_relative < overlap_tol)
     dst_data[nan_indices] = np.nan
 

--- a/pygchem/tools/timeutil.py
+++ b/pygchem/tools/timeutil.py
@@ -10,7 +10,19 @@
 Miscellaneous routine(s) for time iterations and conversions.
 
 """
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import zip
+from builtins import str
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import datetime
 
 from dateutil import rrule
@@ -51,7 +63,7 @@ def time2tau(time, reference=CTM_TIME_REF_DT):
     Convert a datetime object into given hours since reference
     (default: 01.01.1985 00:00).
     """
-    return (time - reference).total_seconds() / 3600.0
+    return old_div((time - reference).total_seconds(), 3600.0)
 
 
 def strp_relativedelta(delta_t):
@@ -64,7 +76,7 @@ def strp_relativedelta(delta_t):
     keys = 'years', 'months', 'days', 'hours', 'minutes', 'seconds'
     vals = [int(i) for i in d.split('-')] + [int(i) for i in t.split(':')]
 
-    return relativedelta(**dict(zip(keys, vals)))
+    return relativedelta(**dict(list(zip(keys, vals))))
 
 
 class DatetimeSlicer(object):
@@ -158,7 +170,7 @@ class DatetimeSlicer(object):
                 except ValueError:
                     min_max = [int(v) for v in val.split(cls._str_range_sep)]
                     min_max[1] += 1
-                    dt_elem.extend(range(*min_max))
+                    dt_elem.extend(list(range(*min_max)))
             args.append(dt_elem)
         return args
 

--- a/pygchem/utils/__init__.py
+++ b/pygchem/utils/__init__.py
@@ -11,3 +11,11 @@ Utility functions and classes that are used in PyGChem, but which are usually
 of no interest to users.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *

--- a/pygchem/utils/check_tools.py
+++ b/pygchem/utils/check_tools.py
@@ -11,7 +11,18 @@
 """
 Module that defines functions for checking various things
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import zip
+from builtins import range
+from past.builtins import basestring
+from builtins import object
 import collections
 
 
@@ -137,24 +148,24 @@ def check_fromref(check, ref, raise_error=True, traceback=[]):
     if isinstance(check, dict):
         # check a dictionary with user defined keys but values of
         # the same type (if ref is a dictionary with a unique key 'anykey')
-        if 'anykey' in ref.keys():
-            lcheck = check.values()
-            lref = ref.values() * len(lcheck)
-            lname = ["key-param '%s'" % k for k in check.keys()]
+        if 'anykey' in list(ref.keys()):
+            lcheck = list(check.values())
+            lref = list(ref.values()) * len(lcheck)
+            lname = ["key-param '%s'" % k for k in list(check.keys())]
         # otherwise, check the keys 
         else:
-            for k in ref.keys():
-                if k not in check.keys():
+            for k in list(ref.keys()):
+                if k not in list(check.keys()):
                     if raise_error:
                         raise ValueError("missing key '%s' in dictionary" % k)
                     check_passes = False
                     break
-            lcheck = [check[k] for k in ref.keys()]
-            lref = ref.values()
-            lname = ["key-param '%s'" % k for k in ref.keys()]
+            lcheck = [check[k] for k in list(ref.keys())]
+            lref = list(ref.values())
+            lname = ["key-param '%s'" % k for k in list(ref.keys())]
     # otherwise: build sequences    
     else:
-        lname = ['index %i' % i for i in xrange(0, len(check))]
+        lname = ['index %i' % i for i in range(0, len(check))]
         lcheck = check
         lref = ref
         if len(lref) < len(lcheck):

--- a/pygchem/utils/custom_decorators.py
+++ b/pygchem/utils/custom_decorators.py
@@ -13,7 +13,15 @@ Module that defines customized decorators
 
 Authors: Gribouillis
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
 from functools import partial
 
 class mixedmethod(object):

--- a/pygchem/utils/data_structures.py
+++ b/pygchem/utils/data_structures.py
@@ -11,7 +11,19 @@ Custom, generic data structures.
 
 """
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import *
+from future import standard_library
+standard_library.install_aliases()
+from builtins import map
+from builtins import str
+from builtins import zip
+from builtins import filter
+from builtins import range
+from builtins import object
 import sys
 import os
 import collections
@@ -21,7 +33,7 @@ from keyword import iskeyword
 from collections import OrderedDict
 from collections import Counter
 try:
-    from UserList import UserList
+    from collections import UserList
 except ImportError:
     from collections import UserList
 
@@ -242,13 +254,11 @@ class RecordList(UserList):
         selection = self.data
         for a in args:
             if not callable(a):
-                selection = filter(lambda obj: getattr(obj, self.key_attr) == a,
-                                   selection)
+                selection = [obj for obj in selection if getattr(obj, self.key_attr) == a]
             else:
-                selection = filter(a, selection)
-        for attr_name, attr_val in kwargs.items():
-            selection = filter(lambda obj: getattr(obj, attr_name) == attr_val,
-                               selection)
+                selection = list(filter(a, selection))
+        for attr_name, attr_val in list(kwargs.items()):
+            selection = [obj for obj in selection if getattr(obj, attr_name) == attr_val]
         return self._create_selection(selection)
 
     def select_one(self, *args, **kwargs):
@@ -306,9 +316,9 @@ class RecordList(UserList):
     def to_dict(self, ordered=False):
         """Return a (ordered) dictionary (`key_attr`: item) from this object."""
         if ordered:
-            return OrderedDict(zip(self.keys, self.data))
+            return OrderedDict(list(zip(self.keys, self.data)))
         else:
-            return dict(zip(self.keys, self.data))
+            return dict(list(zip(self.keys, self.data)))
 
     def insert(self, i, item):
         self._check_before_add(item)
@@ -474,8 +484,8 @@ class Record(object):
 
     def to_dict(self, ordered=False):
         """Return a new dict which maps field names to their values."""
-        kv_pairs = zip(self._properties,
-                       (getattr(self, k) for k in self._properties))
+        kv_pairs = list(zip(self._properties,
+                       (getattr(self, k) for k in self._properties)))
         if ordered:
             return OrderedDict(kv_pairs)
         else:
@@ -489,7 +499,7 @@ class Record(object):
         return len(self._properties)
 
     def __iter__(self):
-        return self.values()
+        return list(self.values())
 
     def __getitem__(self, key):
         return getattr(self, key)
@@ -516,7 +526,7 @@ class Record(object):
         vals = [getattr(self, k) for k in self._properties]
         vals2 = [v if not isinstance(v, RecordList) else repr(v)
                  for v in vals]
-        kv_pairs = zip(self._properties, vals2)
+        kv_pairs = list(zip(self._properties, vals2))
         kv_repr = ', '.join("{0}={1}".format(k, v) for k, v in kv_pairs)
         return "({0})".format(kv_repr)
 
@@ -555,7 +565,7 @@ def record_cls(cls_name, cls_description, fields, required_fields=(),
     # Taken and modified from this recipe:
     # http://code.activestate.com/recipes/576555-records/ (MIT License)
     tfield = ('name', 'type', 'default', 'read_only', 'description')
-    fields = tuple((dict(zip(tfield, f)) for f in fields))
+    fields = tuple((dict(list(zip(tfield, f))) for f in fields))
     for f in fields:
         if f['type'] == str:
             f['default'] = "'{0}'".format(f['default'])
@@ -586,7 +596,7 @@ def record_cls(cls_name, cls_description, fields, required_fields=(),
         if name.startswith('_'):
             raise ValueError("Class name and field names cannot start with an "
                              "underscore: {0}".format(name))
-    for name, count in Counter(field_names).items():
+    for name, count in list(Counter(field_names).items()):
         if count > 1:
             raise ValueError("Encountered duplicate field name: {0}"
                              .format(name))

--- a/pygchem/utils/data_structures.py
+++ b/pygchem/utils/data_structures.py
@@ -10,6 +10,7 @@
 Custom, generic data structures.
 
 """
+from __future__ import print_function
 
 import sys
 import os
@@ -661,11 +662,11 @@ def record_cls(cls_name, cls_description, fields, required_fields=(),
     # Execute the class string in a temporary namespace
     namespace = {}
     try:
-        exec "from pygchem.utils.data_structures import Record" in namespace
-        exec class_str in namespace
+        exec("from pygchem.utils.data_structures import Record", namespace)
+        exec(class_str, namespace)
         if verbose:
             print(class_str)
-    except SyntaxError, e:
+    except SyntaxError as e:
         raise SyntaxError(e.message + ':\n' + class_str)
     cls = namespace[cls_name]
     #cls.__init__.im_func.func_defaults = init_defaults

--- a/pygchem/utils/exceptions.py
+++ b/pygchem/utils/exceptions.py
@@ -10,7 +10,14 @@
 Exceptions specific to the PyGChem package.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import warnings
 import sys
 

--- a/pygchem/utils/fortranformat/FortranRecordReader.py
+++ b/pygchem/utils/fortranformat/FortranRecordReader.py
@@ -1,3 +1,11 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
 import sys
 IS_PYTHON3 = sys.version_info[0] >= 3
 

--- a/pygchem/utils/fortranformat/FortranRecordWriter.py
+++ b/pygchem/utils/fortranformat/FortranRecordWriter.py
@@ -1,3 +1,11 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
 import sys
 IS_PYTHON3 = sys.version_info[0] >= 3
 

--- a/pygchem/utils/fortranformat/__init__.py
+++ b/pygchem/utils/fortranformat/__init__.py
@@ -1,3 +1,10 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 __version__ = '0.2.3'
 
 import sys

--- a/pygchem/utils/fortranformat/_edit_descriptors.py
+++ b/pygchem/utils/fortranformat/_edit_descriptors.py
@@ -1,3 +1,12 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import str
+from builtins import object
 import sys
 IS_PYTHON3 = sys.version_info[0] >= 3
 

--- a/pygchem/utils/fortranformat/_exceptions.py
+++ b/pygchem/utils/fortranformat/_exceptions.py
@@ -1,3 +1,10 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 class InvalidFormat(Exception):
     pass

--- a/pygchem/utils/fortranformat/_input.py
+++ b/pygchem/utils/fortranformat/_input.py
@@ -1,3 +1,12 @@
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import next
+from past.utils import old_div
 import re
 import pdb
 import sys
@@ -345,8 +354,8 @@ def read_float(ed, state, record):
             return (None, state)
     # Special cases: insert a decimal if none specified
     if ('.' not in teststr) and (ed.decimal_places is not None):
-        val = val / 10 ** ed.decimal_places
+        val = old_div(val, 10 ** ed.decimal_places)
     # Apply scale factor if exponent not supplied
     if 'E' not in teststr:
-        val = val / 10 ** state['scale'] 
+        val = old_div(val, 10 ** state['scale']) 
     return (val, state)

--- a/pygchem/utils/fortranformat/_input.py
+++ b/pygchem/utils/fortranformat/_input.py
@@ -227,7 +227,7 @@ def _next(it, default=None):
         if IS_PYTHON3:
             val = next(it)
         else:
-            val = it.next()
+            val = next(it)
     except StopIteration:
         val = default
     return val

--- a/pygchem/utils/fortranformat/_lexer.py
+++ b/pygchem/utils/fortranformat/_lexer.py
@@ -1,3 +1,12 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import str
+from builtins import object
 import sys
 IS_PYTHON3 = sys.version_info[0] >= 3
 

--- a/pygchem/utils/fortranformat/_misc.py
+++ b/pygchem/utils/fortranformat/_misc.py
@@ -21,7 +21,7 @@ class has_next_iterator(object):
       if IS_PYTHON3:
         result = next(self.it)
       else:
-        result = self.it.next()
+        result = next(self.it)
     self._has_next = None
     return result
   def next(self):
@@ -31,7 +31,7 @@ class has_next_iterator(object):
       if IS_PYTHON3:
         result = next(self.it)
       else:
-        result = self.it.next()
+        result = next(self.it)
     self._has_next = None
     return result
   def has_next(self):
@@ -40,7 +40,7 @@ class has_next_iterator(object):
         if IS_PYTHON3:
           self._the_next = next(self.it)
         else:
-          self._the_next = self.it.next()
+          self._the_next = next(self.it)
       except StopIteration: self._has_next = False
       else: self._has_next = True
     return self._has_next

--- a/pygchem/utils/fortranformat/_misc.py
+++ b/pygchem/utils/fortranformat/_misc.py
@@ -1,6 +1,15 @@
 '''
 Miscellaneous functions, classes etc
 '''
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import next
+from builtins import object
 import sys
 IS_PYTHON3 = sys.version_info[0] >= 3
 
@@ -24,7 +33,7 @@ class has_next_iterator(object):
         result = next(self.it)
     self._has_next = None
     return result
-  def next(self):
+  def __next__(self):
     if self._has_next:
       result = self._the_next
     else:

--- a/pygchem/utils/fortranformat/_output.py
+++ b/pygchem/utils/fortranformat/_output.py
@@ -60,7 +60,7 @@ def output(eds, reversion_eds, values):
             if IS_PYTHON3:
                 ed = next(get_ed)
             else:
-                ed = get_ed.next()
+                ed = next(get_ed)
         else:
             if reversion_contains_output_ed == True:
                 # take from reversion edit descriptors if there is a value
@@ -87,7 +87,7 @@ def output(eds, reversion_eds, values):
                 if IS_PYTHON3:
                     val = next(get_value)
                 else:
-                    val = get_value.next()
+                    val = next(get_value)
             else:
                 # is a edit descriptor that requires a value but no value
                 # todo: does it stop gracefully or raise error?

--- a/pygchem/utils/fortranformat/_output.py
+++ b/pygchem/utils/fortranformat/_output.py
@@ -1,3 +1,13 @@
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import next
+from builtins import str
+from past.utils import old_div
 import math
 import itertools
 import sys
@@ -287,7 +297,7 @@ def _compose_float_string(w, e, d, state, val, ftype):
         nb = 0
         save_scale_factor = state['scale']
         exp_d = 10 ** d
-        if (0.0 < tmp < (0.1 - 0.05 / exp_d)) or \
+        if (0.0 < tmp < (0.1 - old_div(0.05, exp_d))) or \
             (tmp >= (exp_d - 0.5)):
             ftype = 'E'
         elif tmp == 0.0:

--- a/pygchem/utils/fortranformat/_parser.py
+++ b/pygchem/utils/fortranformat/_parser.py
@@ -105,7 +105,7 @@ def _expand_parens(tokens):
                     if IS_PYTHON3:
                         t1 = next(get_tokens)
                     else:
-                        t1 = get_tokens.next()
+                        t1 = next(get_tokens)
                 except StopIteration:
                     raise InvalidFormat('Open parens in format')
                 if t1.type == 'LEFT_PARENS':

--- a/pygchem/utils/fortranformat/_parser.py
+++ b/pygchem/utils/fortranformat/_parser.py
@@ -1,3 +1,12 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import str
+from builtins import next
 import sys
 IS_PYTHON3 = sys.version_info[0] >= 3
 

--- a/pygchem/utils/fortranformat/config.py
+++ b/pygchem/utils/fortranformat/config.py
@@ -1,3 +1,10 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import sys
 
 # Should all edit descriptor values be returned even if they were not

--- a/pygchem/utils/fortranformat/config.py
+++ b/pygchem/utils/fortranformat/config.py
@@ -17,7 +17,7 @@ ALLOW_ZERO_WIDTH_EDS = True
 if sys.version_info[0] >= 3:
     PROC_MAXINT = sys.maxsize
 else:
-    PROC_MAXINT = sys.maxint
+    PROC_MAXINT = sys.maxsize
 # Processor dependant default for including leading plus or not
 PROC_INCL_PLUS = False 
 # Option to allow signed binary, octal and hex on input (not a FORTRAN feature)
@@ -45,7 +45,7 @@ def reset():
     if sys.version_info[0] >= 3:
         PROC_MAXINT = sys.maxsize
     else:
-        PROC_MAXINT = sys.maxint
+        PROC_MAXINT = sys.maxsize
     RET_WRITTEN_VARS_ONLY = False
     RET_UNWRITTEN_VARS_NONE = True
     PROC_INCL_PLUS = False

--- a/pygchem/utils/numpyutil.py
+++ b/pygchem/utils/numpyutil.py
@@ -12,7 +12,15 @@
 """
 Miscellaneous routine(s) based on the numpy package
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import range
 import numpy as np
 
 
@@ -25,6 +33,6 @@ def broadcast_1d_array(arr, ndim, axis=1):
     different axes on a multidimensional grid.
     """
     ext_arr = arr
-    for i in xrange(ndim - 1):
+    for i in range(ndim - 1):
         ext_arr = np.expand_dims(ext_arr, axis=axis)
     return ext_arr

--- a/pygchem/utils/tff.py
+++ b/pygchem/utils/tff.py
@@ -10,7 +10,14 @@
 Basic functions for reading / writing formatted (Fortran) text files.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from pygchem.utils.exceptions import NotYetImplementedError
 
 

--- a/pygchem/utils/uff.py
+++ b/pygchem/utils/uff.py
@@ -24,15 +24,16 @@ from builtins import str
 from past.builtins import basestring
 from past.utils import old_div
 import struct
+import io
 
 
 _FIX_ERROR = ("Pre- and suffix of line do not match. This can happen, if the"
               " `endian` is incorrect.")
 
 
-class FortranFile(file):
+class FortranFile(io.FileIO):
     """
-    A class for reading and writing unformatted binary Fortran files. 
+    A class for reading and writing unformatted binary Fortran files.
 
     Parameters
     ----------
@@ -57,7 +58,7 @@ class FortranFile(file):
     way as reading "real lines" in a text file. A format can be given,
     while reading or writing to pack or unpack data into a binary
     format, using the 'struct' module from the Python standard library.
-    
+
     See Documentation of Python's struct module for details on endians and
     format strings: https://docs.python.org/library/struct.html
     """

--- a/pygchem/utils/uff.py
+++ b/pygchem/utils/uff.py
@@ -11,7 +11,18 @@
 Read / write unformatted binary Fortran files.
 
 """
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import zip
+from builtins import str
+from past.builtins import basestring
+from past.utils import old_div
 import struct
 
 
@@ -170,7 +181,7 @@ def _replace_star(fmt, size):
     if n_stars:
         i = fmt.find('*')
         s = struct.calcsize(fmt.replace(fmt[i:i + 2], ''))
-        n = (size - s) / struct.calcsize(fmt[i + 1])
+        n = old_div((size - s), struct.calcsize(fmt[i + 1]))
 
         fmt = fmt.replace('*', str(n))
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def get_package_data(name, extlist):
             #    and os.path.splitext(fname)[1] in extlist):
             #    flist.append(os.path.join(dirpath, fname)[offset:])
             flist.append(os.path.join(dirpath, fname)[offset:])
-    print "Data files to install: %s" % ", ".join(flist)
+    print("Data files to install: %s" % ", ".join(flist))
     return flist
 
 
@@ -37,7 +37,7 @@ def get_subpackages(name):
                 continue
         if os.path.isfile(os.path.join(dirpath, '__init__.py')):
             splist.append(".".join(dirpath.split(os.sep)))
-    print "Packages and subpackages to install: %s" % ", ".join(splist)
+    print("Packages and subpackages to install: %s" % ", ".join(splist))
     return splist
 
 


### PR DESCRIPTION
These changes are the result of running the [automatic 2to3 conversion scripts](http://python-future.org/automatic_conversion.html) to the base PyGChem package. I had to tweak a few additional things, most notably the the inheritance behind FortranFile. But, this seems to work for most things! There are lot of ungainly imports that could be cleaned up and some hand-optimization (e.g. convert all the `old_div` function calls to `//`), but they're mostly cosmetic.

Needs testing and commentary / code review from someone more familiar with this package. This work is a base for the xarray backend WIP I'm about to register on the Issues board.

**TODO**
- [ ] Regression testing for 2/3 compatibility
- [ ] Clean unused and superfluous imports for all modules