### PR TITLE
Backend for loading xarray Datasets from BPCH files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ temp/
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+*.bak
 
 # Packages
 *.egg

--- a/pygchem/__init__.py
+++ b/pygchem/__init__.py
@@ -16,7 +16,14 @@ Code written by Gerrit Kuhlmann is also included in this package.
 :license: GPLv3, see LICENSE for details.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 __all__ = ["config", "globchem", "grid", "diagnostics", "io", "tools",
            "utils"]
 __version__ = '0.3.0dev'

--- a/pygchem/config.py
+++ b/pygchem/config.py
@@ -11,7 +11,14 @@
 PyGChem configuration.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import inspect
 import os
 

--- a/pygchem/dataset_backends/__init__.py
+++ b/pygchem/dataset_backends/__init__.py
@@ -12,3 +12,11 @@ Each backend should be implemented in a Python module named as follows:
 where `name` is the name of the backend or the python library used as backend.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *

--- a/pygchem/dataset_backends/backend_iris.py
+++ b/pygchem/dataset_backends/backend_iris.py
@@ -14,7 +14,17 @@ Also adds support for BPCH format to Iris.
 """
 
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import next
+from builtins import str
+from builtins import zip
+from builtins import range
 import glob
 import warnings
 import datetime
@@ -53,7 +63,7 @@ def _get_datablock_dim_coords(datablock, coord_cache):
     cache_fields = ('modelname', 'resolution', 'origin', 'shape')
     cache_key = '_'.join((str(datablock[f]) for f in cache_fields))
 
-    if cache_key in coord_cache.keys():
+    if cache_key in list(coord_cache.keys()):
         return coord_cache[cache_key]
 
     ctm_grid = grid.CTMGrid.from_model(datablock['modelname'],
@@ -64,7 +74,7 @@ def _get_datablock_dim_coords(datablock, coord_cache):
         shape3 = np.pad(shape, (0, len(origin) - len(shape)), 'constant')
         imin = np.array(origin) - 1
         imax = imin + np.array(shape3)
-        region_box = zip(imin, imax)
+        region_box = list(zip(imin, imax))
     else:
         region_box = None
 
@@ -252,7 +262,7 @@ def fix_bpch2nc(cube, field, filename):
         #dummy_coord = iris.coords.DimCoord([0], long_name='dummy',
         #                                   bounds=[0, 1])
         #cube.add_dim_coord(dummy_coord, 0)
-        return next(cube.slices(range(1, cube.ndim)))
+        return next(cube.slices(list(range(1, cube.ndim))))
 
 
 def fix_bpch2coards(cube, field, filename):

--- a/pygchem/dataset_backends/backend_iris.py
+++ b/pygchem/dataset_backends/backend_iris.py
@@ -252,7 +252,7 @@ def fix_bpch2nc(cube, field, filename):
         #dummy_coord = iris.coords.DimCoord([0], long_name='dummy',
         #                                   bounds=[0, 1])
         #cube.add_dim_coord(dummy_coord, 0)
-        return cube.slices(range(1, cube.ndim)).next()
+        return next(cube.slices(range(1, cube.ndim)))
 
 
 def fix_bpch2coards(cube, field, filename):
@@ -336,7 +336,7 @@ def fix_bpch2coards(cube, field, filename):
                              timeutil.time2tau(tend)]
         if cube.shape[time_dim] == 1:
             slices_dims = [d for d in range(cube.ndim) if d != time_dim]
-            return cube.slices(slices_dims).next()
+            return next(cube.slices(slices_dims))
     except iris.exceptions.CoordinateNotFoundError:
         pass
 

--- a/pygchem/dataset_backends/backend_xarray.py
+++ b/pygchem/dataset_backends/backend_xarray.py
@@ -453,7 +453,7 @@ class _BPCHDataStore_old(xr.backends.common.AbstractDataStore):
             dict(dims=['lev_edge', ], attrs={'axis': 'Z'})
         )
 
-        for vname, data, dims, attrs in self.load_from_datablocks(datablocks, fields, categories):
+        for vname, data, dims, attrs in self._load_from_datablocks(datablocks, fields, categories):
 
             # If requested, try to coerce the attributes and metadata to
             # something a bit more CF-friendly
@@ -526,7 +526,7 @@ class _BPCHDataStore_old(xr.backends.common.AbstractDataStore):
         self._variables['nv'] = xr.Variable(['nv', ], [0, 1])
 
 
-    def load_from_datablocks(self, datablocks, fields=[], categories=[]):
+    def _load_from_datablocks(self, datablocks, fields=[], categories=[]):
         """ Process datablocks returned from read_bpch method for use
         in constructing xarray objects. """
 

--- a/pygchem/dataset_backends/backend_xarray.py
+++ b/pygchem/dataset_backends/backend_xarray.py
@@ -1,0 +1,257 @@
+"""
+Plumbing for enabling BPCH file I/O through xarray.
+"""
+from __future__ import print_function, division
+
+import os
+import numpy as np
+import xarray as xr
+
+from xarray.core.pycompat import OrderedDict
+
+from .. import grid
+from .. diagnostics import CTMDiagnosticInfo
+from .. io import bpch
+
+DEFAULT_DTYPE = np.dtype('f4')
+
+DIMENSIONS = OrderedDict(
+    lon=dict(dims=['lon', ],
+             attrs={
+                'standard_name': 'longitude',
+                'axis': 'X',
+            }
+    ),
+    lat=dict(dims=['lat', ],
+             attrs={
+                'standard_name': 'latitude',
+                'axis': 'Y',
+             },
+    ),
+    lev=dict(dims=['lev', ],
+             attrs={
+                'standard_name': 'sigma',
+                'axis': 'Z',
+             }
+    ),
+    time=dict(dims=['time', ],
+              attrs={
+                'long_name': 'time',
+                'bounds': 'time_bnds',
+              }
+    ),
+    nv=dict(),
+)
+
+def open_bpchdataset(filename,
+                     tracerinfo_file='tracerinfo.dat',
+                     diaginfo_file='diaginfo.dat',
+                     endian=">", default_dtype=DEFAULT_DTYPE):
+
+    store = _BPCHDataStore(
+        filename, tracerinfo_file=tracerinfo_file,
+        diaginfo_file=diaginfo_file, endian=endian,
+        default_dtype=default_dtype
+    )
+    ds = xr.Dataset.load_store(store)
+
+    # ds = xr.decode_cf(ds)
+
+    return ds
+
+
+class _BPCHDataStore(xr.backends.common.AbstractDataStore):
+    """ Backend for representing bpch binary output. """
+
+    def __init__(self, filename,
+                 tracerinfo_file='', diaginfo_file='',
+                 endian=">", default_dtype=DEFAULT_DTYPE):
+        """
+        Note that this should not be used to read in a dataset; instead, see
+        open_bpchdataset.
+
+        """
+
+        # Cache the diagnostic info from this simulation for accessing
+        # grid and metadata information
+        if not tracerinfo_file:
+            tracerinfo_file = 'tracerinfo.dat'
+            if not os.path.exists(tracerinfo_file):
+                tracerinfo_file = ''
+        if not diaginfo_file:
+            diaginfo_file = 'diaginfo.dat'
+            if not os.path.exists(diaginfo_file):
+                diaginfo_file = ''
+        self.ctm_info = CTMDiagnosticInfo(diaginfo_file=diaginfo_file,
+                                          tracerinfo_file=tracerinfo_file)
+
+        # Check endianness flag
+        if endian not in ['>', '<', '=']:
+            raise ValueError("Invalid byte order (endian={})".format(endian))
+        pass
+        self.endian = endian
+
+        # Create storage dicts for variables and attributes, to be used later
+        # when xarray needs to access the data
+        self._variables = xr.core.pycompat.OrderedDict()
+        self._attributes = xr.core.pycompat.OrderedDict()
+        self._dimensions = []
+
+        # Read the BPCH file to figure out what's in it
+        filetype, filetitle, datablocks = bpch.read_bpch(
+            filename, endian=endian, mode='rb',
+            diaginfo_file=diaginfo_file, tracerinfo_file=tracerinfo_file,
+        )
+
+        # Get the list of variables in the file and load all the data:
+        dim_coords = {}
+        times = []
+        time_bnds = []
+        ctm_grid = None
+
+        for datablock in datablocks:
+            # if datablock['name'] != 'O3': continue
+
+            # Record times for constructing coordinates later
+            t0, t1 = datablock['times']
+            if t0 not in times:
+                times.append(t0)
+                time_bnds.append([t0, t1])
+
+            modelname = str(datablock['modelname'], 'utf-8')
+
+            # Only compute the CTM grid once
+            if ctm_grid is None:
+                ctm_grid = grid.CTMGrid.from_model(
+                    modelname, resolution=datablock['resolution']
+                )
+            # dims = _get_datablock_dims(datablock)
+
+            if len(datablock['shape']) == 2:
+                dims = ['time', 'lon', 'lat', ]
+            else:
+                dims = ['time', 'lon', 'lat', 'lev', ]
+            for d in dims:
+                if d not in self._dimensions:
+                    self._dimensions.append(d)
+
+            vname = datablock['category'] + "_" + datablock['name']
+            print(vname)
+            # Create a new variable if it's not already present
+            tracerinfo = datablock['tracerinfo']
+            attrs = dict(
+                long_name=tracerinfo['full_name'],
+                moulecular_weight=tracerinfo['molecular_weight'],
+                scale=tracerinfo['scale'],
+                units=tracerinfo['unit']
+            )
+            # Don't immediately load... let it be lazy!
+            # # TODO: using 'chunks' parameter, wrap this in a dask. delayed() call
+            # if vname in self._variables:
+            #     v = self._variables[vname]
+            #     data = np.concatenate(
+            #         [v.data, datablock['data'][np.newaxis, ...]], axis=0
+            #     )
+            # else:
+            # TODO: Need a better way to concatenate the variable data; doing it this way incurs a huge penalty because everything has to be read from the disk.
+            data = datablock['data']
+
+            var = xr.Variable(dims, data, attrs)
+            # if vname in self._variables:
+            #     var = self._variables[vname].concat(var)
+
+            self._variables[vname] = var
+
+        # Create the dimension variables; we have a lot of options
+        # here with regards to the vertical coordinate. For now,
+        # we'll just use the sigma or eta coordinates.
+        # Useful CF info: http://cfconventions.org/cf-conventions/v1.6.0/cf-conventions.html#_atmosphere_hybrid_sigma_pressure_coordinate
+        # self._variables['Ap'] =
+        # self._variables['Bp'] =
+        # self._variables['altitude'] =
+        if ctm_grid.eta_centers is not None:
+            lev_vals = ctm_grid.eta_centers
+            lev_attrs = {
+                'standard_name': 'atmosphere_hybrid_sigma_pressure_coordinate',
+                'axis': 'Z'
+            }
+        else:
+            lev_vals = ctm_grid.sigma_centers
+            lev_attrs = {
+                'standard_name': 'atmosphere_sigma_coordinate',
+                'axis': 'Z'
+            }
+        self._variables['lev'] = xr.Variable(['lev', ], lev_vals, lev_attrs)
+
+        # Latitude / Longitude
+        # TODO: Add lon/lat bounds
+        self._variables['lon'] = xr.Variable(
+            ['lon'], ctm_grid.lonlat_centers[0],
+            {'long_name': 'longitude', 'units': 'degrees_east'}
+        )
+        self._variables['lat'] = xr.Variable(
+            ['lat'], ctm_grid.lonlat_centers[1],
+            {'long_name': 'latitude', 'units': 'degrees_north'}
+        )
+        # TODO: Fix longitudes if ctm_grid.center180
+
+        # Time dimensions
+        # TODO: Time units?
+        self._variables['time'] = xr.Variable(
+            ['time', ], times,
+            {'bounds': 'time_bnds'}
+        )
+        self._variables['time_bnds'] = xr.Variable(
+            ['time', 'nv'], time_bnds, {}
+        )
+
+
+
+    def _get_datablock_dims(datablock):
+        """
+        Compute the grid diemsnsions for a given datablock.
+
+        This is mostly culled from backend_iris._get_datablock_dim_coords
+        and irisutil.coord_from_grid, with some modifications for
+        pertinence to xarray.
+
+        """
+        modelname = str(datablock['modelname'], 'utf-8')
+
+        ctm_grid = grid.CTMGrid.from_model(
+            modelname, resolution=datablock['resolution']
+        )
+
+        # verify if `ctm_grid` is compatible with requested coordinates
+        if ctm_grid.Nlayers is None and any(c in vcoord_names for c in coord):
+            raise ValueError("vertical coordinate(s) requested but the '{0}' grid "
+                             "has no defined vertical layers"
+                             .format(ctm_grid.model))
+        if 'sigma' in coord and ctm_grid.hybrid:
+            raise ValueError("sigma coordinate requested but the '{0}' grid have "
+                             "hybrid vertical layers ".format(ctm_grid.model))
+        if 'eta' in coord and not ctm_grid.hybrid:
+            raise ValueError("eta coordinate requested but the '{0}' grid doesn't "
+                             "have hybrid vertical layers ".format(ctm_grid.model))
+
+        # Reshape coordinate bounds from shape (n+1) to shape (n, 2).
+        reshape_bounds = lambda bounds: np.column_stack((bounds[:-1], bounds[1:]))
+
+        dims = [
+            ()
+        ]
+
+        return dims
+
+
+    def get_variables(self):
+        return self._variables
+
+    def get_attrs(self):
+        return self._attributes
+
+    def get_dimensions(self):
+        return self._dimensions
+
+    def close(self):
+        pass

--- a/pygchem/dataset_backends/backend_xarray.py
+++ b/pygchem/dataset_backends/backend_xarray.py
@@ -90,11 +90,13 @@ class BPCHDataProxyWrapper(NDArrayMixin):
 
     @property
     def array(self):
-        return self._array.data
+        data = self._array.data
+        print(type(data))
+        return data
 
     @property
     def dtype(self):
-        return self.array.dtype
+        return self._array.dtype
 
     def __getitem__(self, key):
         print(key)

--- a/pygchem/dataset_backends/backend_xarray.py
+++ b/pygchem/dataset_backends/backend_xarray.py
@@ -41,10 +41,48 @@ DIMENSIONS = OrderedDict(
     nv=dict(),
 )
 
-def open_bpchdataset(filename, fields=[], fix_cf=True,
+#: CF/COARDS recommended dimension order; non-spatiotemporal dimensions
+#: should precede these.
+DIM_ORDER_PRIORITY = ['time', 'lev', 'lat', 'lon']
+
+def open_bpchdataset(filename, fields=[], fix_cf=True, fix_dims=False,
                      tracerinfo_file='tracerinfo.dat',
                      diaginfo_file='diaginfo.dat',
-                     endian=">", default_dtype=DEFAULT_DTYPE):
+                     endian=">", default_dtype=DEFAULT_DTYPE, chunks=None):
+    """ Open a GEOS-Chem BPCH file output as an xarray Dataset.
+
+    Parameters
+    ----------
+    filename : string
+        Path to the output file to read in.
+    {tracerinfo,diaginfo}_file : string, optional
+        Path to the metadata "info" .dat files which are used to decipher
+        the metadata corresponding to each variable in the output dataset.
+        If not provided, will look for them in the current directory or
+        fall back on a generic set.
+    fields : list, optional
+        List of a subset of variable names to return. This can substantially
+        improve read performance. Note that the field here is just the tracer
+        name - not the category, e.g. 'O3' instead of 'IJ-AVG-$_O3'.
+    fix_cf : logical, optional
+        Conform units, standard names, and other metadata to CF standards when
+        reading in data.
+    fix_dims : logical, optional
+        Transpose dimensions on disk to (T, Z, Y, X) (CF-compliant) order when
+        reading in data.
+    endian : {'=', '>', '<'}, optional
+        Endianness of file on disk. By default, "big endian" (">") is assumed.
+    default_dtype : numpy.dtype, optional
+        Default datatype for variables encoded in file on disk (single-precision
+        float by default).
+
+    Returns
+    -------
+    ds : xarray.Dataset
+        Dataset containing the requested fields (or the entire file), with data
+        contained in proxy containers for access later.
+
+    """
 
     # Do a preliminary read of the BPCH file to construct a map of its
     # contents. This doesn't read anything into memory, and should be
@@ -56,68 +94,24 @@ def open_bpchdataset(filename, fields=[], fix_cf=True,
     # bpch_contents = _get_bpch_contents(datablocks)
 
     store = _BPCHDataStore(
-        filename, fields=fields, fix_cf=fix_cf,
+        filename, fields=fields, fix_cf=fix_cf, fix_dims=fix_dims,
         tracerinfo_file=tracerinfo_file,
         diaginfo_file=diaginfo_file, endian=endian,
-        default_dtype=default_dtype
+        default_dtype=default_dtype,
     )
 
     ds = xr.Dataset.load_store(store)
 
-    # ds = xr.decode_cf(ds)
+    # To immediately load the data from the BPCHDataProxy paylods, need
+    # to execute ds.data_vars for some reason...
 
     return ds
-
-
-# def _get_bpch_contents(datablocks):
-#     """ Generate sufficient information to create separate Datasets for each
-#     field and timeslice in a given BPCH output dataset. """
-#
-#     for datablock in datablocks:
-#
-#         vname = datablock['category'] + "_" + datablock['name']
-#
-#         # Create a new variable if it's not already present
-#         tracerinfo = datablock['tracerinfo']
-#         attrs = dict(
-#             long_name=tracerinfo['full_name'],
-#             moulecular_weight=tracerinfo['molecular_weight'],
-#             scale=tracerinfo['scale'],
-#             units=tracerinfo['unit']
-#         )
-#
-#         shape, origin, times = \
-#             datablock['shape'], datablock['origin'], datablock['times']
-#
-#         if len(shape) == 2:
-#             dims = ['time', 'lon', 'lat', ]
-#         else:
-#             dims = ['time', 'lon', 'lat', 'lev', ]
-#
-#         # Don't immediately load... let it be lazy!
-#         # # TODO: using 'chunks' parameter, wrap this in a dask. delayed() call
-#         # if vname in self._variables:
-#         #     v = self._variables[vname]
-#         #     data = np.concatenate(
-#         #         [v.data, datablock['data'][np.newaxis, ...]], axis=0
-#         #     )
-#         # else:
-#         # TODO: Need a better way to concatenate the variable data; doing it this way incurs a huge penalty because everything has to be read from the disk.
-#         data = datablock['data'][None]
-#
-#         var = xr.Variable(dims, data, attrs)
-#         # if vname in self._variables:
-#         #     var = self._variables[vname].concat(var)
-#
-#         self._variables[vname] = var
-
-
 
 
 class _BPCHDataStore(xr.backends.common.AbstractDataStore):
     """ Backend for representing bpch binary output. """
 
-    def __init__(self, filename, fields=[], fix_cf=True,
+    def __init__(self, filename, fields=[], fix_cf=True, fix_dims=False,
                  tracerinfo_file='', diaginfo_file='',
                  endian=">", default_dtype=DEFAULT_DTYPE):
         """
@@ -156,7 +150,7 @@ class _BPCHDataStore(xr.backends.common.AbstractDataStore):
         read_bpch_kws = dict(
             endian=endian, mode='rb',
             diaginfo_file=diaginfo_file, tracerinfo_file=tracerinfo_file,
-            dummy_prefix_dims=1, concat_blocks=True,
+            dummy_prefix_dims=1, concat_blocks=True
         )
         header_info = bpch.read_bpch(
             filename, first_header=True, **read_bpch_kws
@@ -183,7 +177,19 @@ class _BPCHDataStore(xr.backends.common.AbstractDataStore):
                     attrs['units'] = cf_units
                 vname = ctm2cf.get_valid_varname(vname)
 
+            # data = data.load_memmap()
             var = xr.Variable(dims, data, attrs)
+
+            # Shuffle dims for CF/COARDS compliance if requested
+            # TODO: For this to work, we have to force a load of the data.
+            #       Is there a way to re-write BPCHDataProxy so that that's not
+            #       necessary?
+            #       Actually, we can't even force a load becase var.data is a
+            #       numpy.ndarray. Weird.
+            if fix_dims:
+                target_dims = [d for d in DIM_ORDER_PRIORITY if d in dims]
+                var = var.transpose(*target_dims)
+
             self._variables[vname] = var
 
         # Create the dimension variables; we have a lot of options
@@ -231,6 +237,8 @@ class _BPCHDataStore(xr.backends.common.AbstractDataStore):
         )
 
     def load_from_datablocks(self, datablocks, fields=[]):
+        """ Process datablocks returned from read_bpch method for use
+        in constructing xarray objects. """
 
         for datablock in datablocks:
             name = datablock['name']
@@ -267,7 +275,7 @@ class _BPCHDataStore(xr.backends.common.AbstractDataStore):
 
     def _get_datablock_dims(datablock):
         """
-        Compute the grid diemsnsions for a given datablock.
+        Compute the grid dimensions for a given datablock.
 
         This is mostly culled from backend_iris._get_datablock_dim_coords
         and irisutil.coord_from_grid, with some modifications for
@@ -312,4 +320,5 @@ class _BPCHDataStore(xr.backends.common.AbstractDataStore):
         return self._dimensions
 
     def close(self):
-        pass
+        for var in list(self._variables):
+            del self._variables['var']

--- a/pygchem/dataset_backends/backend_xarray.py
+++ b/pygchem/dataset_backends/backend_xarray.py
@@ -208,8 +208,8 @@ class _BPCHDataStore(xr.backends.common.AbstractDataStore):
                 vname = ctm2cf.get_valid_varname(vname)
 
             # data = data.load_memmap()
-            # TODO: Explore using a wrapper with an NDArrayMixin, but I don't necessarily think it's useful or helpful here.
-            # data = BPCHDataProxyWrapper(data)
+            # TODO: Explore using a wrapper with an NDArrayMixin; if you don't do this, then dask won't work correctly (it won't promote the data to an array from a BPCHDataProxy). I'm not sure why.
+            data = BPCHDataProxyWrapper(data)
             var = xr.Variable(dims, data, attrs)
 
             # Shuffle dims for CF/COARDS compliance if requested

--- a/pygchem/dataset_backends/backend_xarray.py
+++ b/pygchem/dataset_backends/backend_xarray.py
@@ -36,10 +36,7 @@ DIMENSIONS = OrderedDict(
              }
     ),
     time=dict(dims=['time', ],
-              attrs={
-                'long_name': 'time',
-                'bounds': 'time_bnds',
-              }
+              attrs={}
     ),
     nv=dict(),
 )
@@ -226,10 +223,11 @@ class _BPCHDataStore(xr.backends.common.AbstractDataStore):
         # TODO: Time units?
         self._variables['time'] = xr.Variable(
             ['time', ], self._times,
-            {'bounds': 'time_bnds'}
+            {'bounds': 'time_bnds', 'units': ctm2cf.CTM_TIME_UNIT_STR}
         )
         self._variables['time_bnds'] = xr.Variable(
-            ['time', 'nv'], self._time_bnds, {}
+            ['time', 'nv'], self._time_bnds,
+            {'units': ctm2cf.CTM_TIME_UNIT_STR}
         )
 
     def load_from_datablocks(self, datablocks, fields=[]):

--- a/pygchem/dataset_backends/backend_xarray.py
+++ b/pygchem/dataset_backends/backend_xarray.py
@@ -70,7 +70,7 @@ class BPCHDataProxyWrapper(NDArrayMixin):
 
 
 def open_bpchdataset(filename, fields=[], categories=[],
-                     fix_cf=True, fix_dims=False,
+                     fix_cf=True, fix_dims=False, maskandscale=True,
                      tracerinfo_file='tracerinfo.dat',
                      diaginfo_file='diaginfo.dat',
                      endian=">", default_dtype=DEFAULT_DTYPE,
@@ -99,6 +99,10 @@ def open_bpchdataset(filename, fields=[], categories=[],
     fix_dims : logical, optional
         Transpose dimensions on disk to (T, Z, Y, X) (CF-compliant) order when
         reading in data.
+    maskandscale : logical, optional
+        Apply scaling to data according to metadata in BPCH file; this might
+        slow down some read operations, depending on how eagerly xarray
+        tries to evaluate operations.
     endian : {'=', '>', '<'}, optional
         Endianness of file on disk. By default, "big endian" (">") is assumed.
     default_dtype : numpy.dtype, optional
@@ -142,7 +146,7 @@ class _BPCHDataStore(xr.backends.common.AbstractDataStore):
     """ Backend for representing bpch binary output. """
 
     def __init__(self, filename, fields=[], categories=[],
-                 fix_cf=True, fix_dims=False,
+                 fix_cf=True, fix_dims=False, maskandscale=True,
                  tracerinfo_file='', diaginfo_file='',
                  endian=">", default_dtype=DEFAULT_DTYPE,
                  memmap=True, use_dask=True):
@@ -185,7 +189,7 @@ class _BPCHDataStore(xr.backends.common.AbstractDataStore):
         read_bpch_kws = dict(
             endian=endian, mode='rb',
             diaginfo_file=diaginfo_file, tracerinfo_file=tracerinfo_file,
-            dummy_prefix_dims=1, concat_blocks=True, maskandscale=False,
+            dummy_prefix_dims=1, concat_blocks=True, maskandscale=maskandscale,
             memmap=memmap, use_dask=use_dask
         )
         header_info = bpch.read_bpch(

--- a/pygchem/dataset_backends/backend_xarray.py
+++ b/pygchem/dataset_backends/backend_xarray.py
@@ -3,12 +3,15 @@ Plumbing for enabling BPCH file I/O through xarray.
 """
 from __future__ import print_function, division
 
+import functools
 import os
 import numpy as np
 import xarray as xr
 import warnings
 
 from xarray.core.pycompat import OrderedDict
+from xarray.core.variable import  Variable
+from xarray.backends.common import AbstractDataStore
 from xarray.core.utils import Frozen, FrozenOrderedDict, NDArrayMixin
 from xarray.core import indexing
 
@@ -44,6 +47,36 @@ BASE_DIMENSIONS =   OrderedDict(
 #: CF/COARDS recommended dimension order; non-spatiotemporal dimensions
 #: should precede these.
 DIM_ORDER_PRIORITY = ['time', 'lev', 'lat', 'lon']
+
+class BPCHMixin(object):
+    """ Mixin for adding pre-set grid and other information into a BPCH
+    dataset. """
+
+    def set_horizontal_grid(self):
+        pass
+
+    def _infer_dims(self):
+        pass
+
+class BPCHVariableWrapper(indexing.NumpyIndexingAdapter):
+
+    def __init__(self, variable_name, datastore):
+        self.datastore = datastore
+        self.variable_name = variable_name
+
+    @property
+    def array(self):
+        return self.datastore.ds.variables[self.variable_name].data
+
+    @property
+    def dtype(self):
+        return np.dtype(self.array.dtype.kind + str(self.array.dtype.itemsize))
+
+    def __getitem__(self, key):
+        data = super(BPCHVariableWrapper, self).__getitem__(key)
+        copy = self.datastore.memmap
+        data = np.array(data, dtype=self.dtype, copy=copy)
+        return data
 
 
 class BPCHDataProxyWrapper(NDArrayMixin):
@@ -128,10 +161,9 @@ def open_bpchdataset(filename, fields=[], categories=[],
 
     store = _BPCHDataStore(
         filename, fields=fields, categories=categories,
-        fix_cf=fix_cf, fix_dims=fix_dims,
+        fix_cf=fix_cf,
         tracerinfo_file=tracerinfo_file,
-        diaginfo_file=diaginfo_file, endian=endian,
-        default_dtype=default_dtype, memmap=memmap, use_dask=use_dask
+        diaginfo_file=diaginfo_file, endian=endian, memmap=memmap
     )
 
     ds = xr.Dataset.load_store(store)
@@ -141,8 +173,201 @@ def open_bpchdataset(filename, fields=[], categories=[],
 
     return ds
 
+class _BPCHDataStore(AbstractDataStore):
+    """Store for reading data via pygchem.io.bpch_file.
 
-class _BPCHDataStore(xr.backends.common.AbstractDataStore):
+    """
+    def __init__(self, filename, fields=[], categories=[],
+                 mode='r', endian='>', memmap=True,
+                 diaginfo_file='', tracerinfo_file='',
+                 maskandscale=False, fix_cf=False):
+
+        if not tracerinfo_file:
+            tracerinfo_file = 'tracerinfo.dat'
+            if not os.path.exists(tracerinfo_file):
+                tracerinfo_file = ''
+        if not diaginfo_file:
+            diaginfo_file = 'diaginfo.dat'
+            if not os.path.exists(diaginfo_file):
+                diaginfo_file = ''
+
+
+        # Check endianness flag
+        if endian not in ['>', '<', '=']:
+            raise ValueError("Invalid byte order (endian={})".format(endian))
+        pass
+        self.endian = endian
+
+
+        opener = functools.partial(
+            bpch.bpch_file, filename=filename,
+            mode=mode, endian=self.endian, memmap=memmap,
+            diaginfo_file=diaginfo_file, tracerinfo_file=tracerinfo_file,
+            maskandscale=maskandscale)
+
+        self.ds = opener()
+        self._opener = opener
+        self.memmap = memmap
+
+        self.maskandscale = maskandscale
+        self.fields = fields
+        self.categories = categories
+
+        self.ctm_info = self.ds.ctm_info
+
+        # Create storage dicts for variables and attributes, to be used later
+        # when xarray needs to access the data
+        self._variables = xr.core.pycompat.OrderedDict()
+        self._attributes = xr.core.pycompat.OrderedDict()
+        self._attributes.update(self.ds._attributes)
+        self._dimensions = [d for d in BASE_DIMENSIONS]
+
+        # Get the list of variables in the file and load all the data:
+        dim_coords = {}
+        self._times = self.ds.times
+        print(len(self._times))
+        self._time_bnds = self.ds.time_bnds
+        print(self._attributes)
+        self.ctm_grid = grid.CTMGrid.from_model(
+            self._attributes['modelname'], resolution=self._attributes['res']
+        )
+
+        # Add vertical dimensions
+        self._dimensions.append(
+            dict(dims=['lev', ], attrs={'axis': 'Z'})
+        )
+        self._dimensions.append(
+            dict(dims=['lev_trop', ], attrs={'axis': 'Z'})
+        )
+        self._dimensions.append(
+            dict(dims=['lev_edge', ], attrs={'axis': 'Z'})
+        )
+
+        for vname, v in self.ds.variables.items():
+            if fields and (v.attributes['name'] not in fields):
+                continue
+            if categories and (v.attributes['category ']not in categories):
+                continue
+
+            # Process dimensions
+            dims = ['time', 'lon', 'lat', ]
+            dshape = v.shape
+            if len(dshape) > 3:
+                # Process the vertical coordinate. A few things can happen here:
+                # 1) We have cell-centered values on the "Nlayer" grid; we can take these variables and map them to 'lev'
+                # 2) We have edge value on an "Nlayer" + 1 grid; we can take these and use them with 'lev_edge'
+                # 3) We have troposphere values on "Ntrop"; we can take these and use them with 'lev_trop', but we won't have coordinate information yet
+                # All other cases we do not handle yet; this includes the aircraft emissions and a few other things. Note that tracer sources do not have a vertical coord to worry about!
+                nlev = dshape[-1]
+                try:
+                    if nlev == self.ctm_grid.Nlayers:
+                        dims.append('lev')
+                    elif nlev == self.ctm_grid.Nlayers + 1:
+                        dims.append('lev_edge')
+                    elif nlev == self.ctm_grid.Ntrop:
+                        dims.append('lev_trop')
+                    else:
+                        continue
+                except AttributeError:
+                    warnings.warn("Couldn't resolve attributes on ctm_grid")
+                    continue
+
+            # Is the variable time-invariant? If it is, kill the time dim.
+            # Here, we mean it only as one sample in the dataset.
+            if dshape[0] == 1:
+                del dims[0]
+
+
+            # If requested, try to coerce the attributes and metadata to
+            # something a bit more CF-friendly
+            lookup_name = vname
+            if fix_cf:
+                if 'units' in v.attributes:
+                    cf_units = ctm2cf.get_cfcompliant_units(
+                        v.attributes['units']
+                    )
+                    v.attributes['units'] = cf_units
+                vname = ctm2cf.get_valid_varname(vname)
+
+            # TODO: Explore using a wrapper with an NDArrayMixin; if you don't do this, then dask won't work correctly (it won't promote the data to an array from a BPCHDataProxy). I'm not sure why.
+            data = BPCHVariableWrapper(lookup_name, self)
+            var = xr.Variable(dims, data, v.attributes)
+
+            # Shuffle dims for CF/COARDS compliance if requested
+            # TODO: For this to work, we have to force a load of the data.
+            #       Is there a way to re-write BPCHDataProxy so that that's not
+            #       necessary?
+            #       Actually, we can't even force a load becase var.data is a
+            #       numpy.ndarray. Weird.
+            # if fix_dims:
+            #     target_dims = [d for d in DIM_ORDER_PRIORITY if d in dims]
+            #     var = var.transpose(*target_dims)
+
+            self._variables[vname] = var
+
+        # Create the dimension variables; we have a lot of options
+        # here with regards to the vertical coordinate. For now,
+        # we'll just use the sigma or eta coordinates.
+        # Useful CF info: http://cfconventions.org/cf-conventions/v1.6.0/cf-conventions.html#_atmosphere_hybrid_sigma_pressure_coordinate
+        # self._variables['Ap'] =
+        # self._variables['Bp'] =
+        # self._variables['altitude'] =
+        if self.ctm_grid.eta_centers is not None:
+            lev_vals = self.ctm_grid.eta_centers
+            lev_attrs = {
+                'standard_name': 'atmosphere_hybrid_sigma_pressure_coordinate',
+                'axis': 'Z'
+            }
+        else:
+            lev_vals = self.ctm_grid.sigma_centers
+            lev_attrs = {
+                'standard_name': 'atmosphere_hybrid_sigma_pressure_coordinate',
+                'axis': 'Z'
+            }
+        self._variables['lev'] = xr.Variable(['lev', ], lev_vals, lev_attrs)
+
+        # Latitude / Longitude
+        # TODO: Add lon/lat bounds
+        self._variables['lon'] = xr.Variable(
+            ['lon'], self.ctm_grid.lonlat_centers[0],
+            {'long_name': 'longitude', 'units': 'degrees_east'}
+        )
+        self._variables['lat'] = xr.Variable(
+            ['lat'], self.ctm_grid.lonlat_centers[1],
+            {'long_name': 'latitude', 'units': 'degrees_north'}
+        )
+        # TODO: Fix longitudes if ctm_grid.center180
+
+        # Time dimensions
+        # TODO: Time units?
+        self._variables['time'] = xr.Variable(
+            ['time', ], self._times,
+            {'bounds': 'time_bnds', 'units': ctm2cf.CTM_TIME_UNIT_STR}
+        )
+        self._variables['time_bnds'] = xr.Variable(
+            ['time', 'nv'], self._time_bnds,
+            {'units': ctm2cf.CTM_TIME_UNIT_STR}
+        )
+        self._variables['nv'] = xr.Variable(['nv', ], [0, 1])
+
+    def get_variables(self):
+        return self._variables
+
+    def get_attrs(self):
+        return Frozen(self._attributes)
+
+    def get_dimensions(self):
+        return Frozen(self._dimensions)
+
+
+    def close(self):
+        self.ds.close()
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
+
+class _BPCHDataStore_old(xr.backends.common.AbstractDataStore):
     """ Backend for representing bpch binary output. """
 
     def __init__(self, filename, fields=[], categories=[],
@@ -360,42 +585,6 @@ class _BPCHDataStore(xr.backends.common.AbstractDataStore):
 
             yield vname, data, dims, attrs
 
-
-    def _get_datablock_dims(datablock):
-        """
-        Compute the grid dimensions for a given datablock.
-
-        This is mostly culled from backend_iris._get_datablock_dim_coords
-        and irisutil.coord_from_grid, with some modifications for
-        pertinence to xarray.
-
-        """
-        modelname = str(datablock['modelname'], 'utf-8')
-
-        ctm_grid = grid.CTMGrid.from_model(
-            modelname, resolution=datablock['resolution']
-        )
-
-        # verify if `ctm_grid` is compatible with requested coordinates
-        if ctm_grid.Nlayers is None and any(c in vcoord_names for c in coord):
-            raise ValueError("vertical coordinate(s) requested but the '{0}' grid "
-                             "has no defined vertical layers"
-                             .format(ctm_grid.model))
-        if 'sigma' in coord and ctm_grid.hybrid:
-            raise ValueError("sigma coordinate requested but the '{0}' grid have "
-                             "hybrid vertical layers ".format(ctm_grid.model))
-        if 'eta' in coord and not ctm_grid.hybrid:
-            raise ValueError("eta coordinate requested but the '{0}' grid doesn't "
-                             "have hybrid vertical layers ".format(ctm_grid.model))
-
-        # Reshape coordinate bounds from shape (n+1) to shape (n, 2).
-        reshape_bounds = lambda bounds: np.column_stack((bounds[:-1], bounds[1:]))
-
-        dims = [
-            ()
-        ]
-
-        return dims
 
     def get_variables(self):
         return self._variables

--- a/pygchem/dataset_backends/backend_xarray.py
+++ b/pygchem/dataset_backends/backend_xarray.py
@@ -173,7 +173,6 @@ class _BPCHDataStore(xr.backends.common.AbstractDataStore):
         )
 
         for vname, data, dims, attrs in self.load_from_datablocks(datablocks):
-            print(vname, dims)
             var = xr.Variable(dims, data, attrs)
             self._variables[vname] = var
 
@@ -184,7 +183,6 @@ class _BPCHDataStore(xr.backends.common.AbstractDataStore):
         # self._variables['Ap'] =
         # self._variables['Bp'] =
         # self._variables['altitude'] =
-        print(ctm_grid)
         if ctm_grid.eta_centers is not None:
             lev_vals = ctm_grid.eta_centers
             lev_attrs = {
@@ -242,7 +240,6 @@ class _BPCHDataStore(xr.backends.common.AbstractDataStore):
                 dims = ['lon', 'lat', 'lev', ]
             dims = ['time', ] + dims
 
-            print(vname)
             # Create a new variable if it's not already present
             tracerinfo = datablock['tracerinfo']
             attrs = dict(
@@ -251,18 +248,7 @@ class _BPCHDataStore(xr.backends.common.AbstractDataStore):
                 scale=tracerinfo['scale'],
                 units=tracerinfo['unit']
             )
-            # Don't immediately load... let it be lazy!
-            # # # TODO: using 'chunks' parameter, wrap this in a dask. delayed() call
-            # if vname in self._variables:
-            #     v = self._variables[vname]
-            #     new_data = datablock['data']
-            #     data = np.concatenate(
-            #         [v.data, new_data], axis=0
-            #     )
-            # else:
-            # TODO: Need a better way to concatenate the variable data; doing it this way incurs a huge penalty because everything has to be read from the disk.
             data = datablock['data']
-            print(datablock['data'].file_positions)
 
             yield vname, data, dims, attrs
 

--- a/pygchem/datasets.py
+++ b/pygchem/datasets.py
@@ -11,7 +11,14 @@ GEOS-Chem datasets I/O using one of the available
 backends ('iris', 'netcdf', 'bpch').
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import importlib
 from contextlib import contextmanager
 

--- a/pygchem/diagnostics.py
+++ b/pygchem/diagnostics.py
@@ -11,7 +11,15 @@ GEOS-Chem diagnostics (set/get metadata to/from files 'tracerinfo.dat'
 and 'diaginfo.dat').
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
 import os
 
 from pygchem import config

--- a/pygchem/emissions.py
+++ b/pygchem/emissions.py
@@ -10,7 +10,17 @@
 Interface to the Harvard-NASA Emissions Component (HEMCO).
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import str
+from builtins import range
+from builtins import object
 import os
 
 from pygchem import config
@@ -362,7 +372,7 @@ class EmissionSetup(object):
         """
         fids = self.get_fids()
         min_fid = min(i for i in fids if i is not None)
-        range_fids = range(min_fid, max(fids) + len(fids) + 1)
+        range_fids = list(range(min_fid, max(fids) + len(fids) + 1))
         duplicate_fids = set([fid for fid in fids if fids.count(fid) > 1])
         available_fids = sorted(set(range_fids) - set(fids))
 
@@ -379,7 +389,7 @@ class EmissionSetup(object):
 
         eids = self.get_eids()
         min_eid = min(i for i in eids if i is not None)
-        range_eids = range(min_eid, max(eids) + len(eids) + 1)
+        range_eids = list(range(min_eid, max(eids) + len(eids) + 1))
         duplicate_eids = set([eid for eid in eids if eids.count(eid) > 1])
         available_eids = sorted(set(range_eids) - set(eids))
 

--- a/pygchem/globchem.py
+++ b/pygchem/globchem.py
@@ -20,7 +20,21 @@ FAST-J). The data is commonly stored in the files "globchem.dat",
 TODO: show here some examples.
 
 """
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import map
+from builtins import zip
+from builtins import str
+from builtins import range
+from past.builtins import basestring
+from past.utils import old_div
+from builtins import object
 import collections
 import types
 import numbers
@@ -120,7 +134,7 @@ class Species(object):
         if not isinstance(val, basestring):
             raise TypeError("Bad type for id: expected string, got %s"
                             % type(val).__name__)
-        if len(val) not in xrange(1, 11):
+        if len(val) not in list(range(1, 11)):
             raise ValueError("Length of id string cannot contain more than "
                              "11 characters (but at least 1 character)")
         self._id = val.upper()
@@ -136,7 +150,7 @@ class Species(object):
         if not isinstance(val, basestring):
             raise TypeError("Bad type for name: expected string, got %s"
                             % type(val).__name__)
-        if len(val) not in xrange(0, 40):
+        if len(val) not in list(range(0, 40)):
             raise ValueError("Length of name string cannot contain more than "
                              "40 characters")
         self._name = val
@@ -152,7 +166,7 @@ class Species(object):
         if not isinstance(val, basestring):
             raise TypeError("Bad type for formula: expected string, got %s"
                             % type(val).__name__)
-        if len(val) not in xrange(0, 32):
+        if len(val) not in list(range(0, 32)):
             raise ValueError("Length of name string cannot contain more than "
                              "32 characters")
         self._formula = val.upper()
@@ -169,7 +183,7 @@ class Species(object):
         if not isinstance(val, basestring):
             raise TypeError("Bad type for status: expected string, got %s"
                             % type(val).__name__)
-        if val not in self.valid_status.keys():
+        if val not in list(self.valid_status.keys()):
             raise ValueError("Bad value for status: expected one of the "
                              "following capital letters:\n%s"
                              % pprint.pformat(self.valid_status))
@@ -229,7 +243,7 @@ class Species(object):
     @mb_groups.setter
     def mb_groups(self, val):
         if (not isinstance(val, dict)
-            or not all(isinstance(v, numbers.Integral) for v in val.values())):
+            or not all(isinstance(v, numbers.Integral) for v in list(val.values()))):
             raise ValueError("mb_groups must be a dictionary with int values")
         self._mb_groups = val
 
@@ -253,11 +267,11 @@ class Species(object):
         """
         spec = cls(species_dict['id'])
         for k in cls.get_attributes():
-            if k not in species_dict.keys():
+            if k not in list(species_dict.keys()):
                 warnings.warn("species attribute '%s' not in the dictionary, "
                               "default value %s used"
                               % (k, str(getattr(spec, k))))
-        for k, v in species_dict.items():
+        for k, v in list(species_dict.items()):
             setattr(spec, k, v)
         return spec
 
@@ -265,7 +279,7 @@ class Species(object):
         """
         Return a :class:`Species` object as a python dictionary
         """
-        dict_attr_names = [k for k in self.__dict__.keys() if k[0] != '_']
+        dict_attr_names = [k for k in list(self.__dict__.keys()) if k[0] != '_']
         attr_names = set(dict_attr_names + self.get_attributes())
 
         return {k: getattr(self, k) for k in attr_names}
@@ -276,7 +290,7 @@ class Species(object):
         Return a list of the names of the :class:`Species` built-in attributes 
         (i.e., properties). 
         """
-        return [k for k, v in cls.__dict__.items() if type(v) == property]
+        return [k for k, v in list(cls.__dict__.items()) if type(v) == property]
 
 
 class ReactionRate(object):
@@ -344,10 +358,10 @@ class ReactionRate(object):
 
         info = {'flag': flags, 'function': functions, 'fname': fnames,
                 'descr': descr}
-        if key not in info.keys() or val not in info.keys():
+        if key not in list(info.keys()) or val not in list(info.keys()):
             raise ValueError("invalid argument(s) key and/or val")
 
-        return dict(zip(info[key], info[val]))
+        return dict(list(zip(info[key], info[val])))
 
     @classmethod
     def get_ratef_fromflag(cls, flag):
@@ -387,7 +401,7 @@ class ReactionRate(object):
         arr : list of 3 floats
             parameters [A,B,C] of the rate constant expression
         """
-        return arr[0] * (300 / T) ** arr[1] * np.exp(arr[2] / T)
+        return arr[0] * (old_div(300, T)) ** arr[1] * np.exp(old_div(arr[2], T))
 
     @classmethod
     def p_ratek(cls, T, cM, arrlow=[0., 0., 0.], arrhigh=[0., 0., 0.],
@@ -437,15 +451,15 @@ class ReactionRate(object):
         Pr = K0 * cM / Kinf
 
         if falloff[2] != 0.:
-            Fc = math.exp(-T / falloff[1]) + math.exp(-falloff[2] / T)
+            Fc = math.exp(old_div(-T, falloff[1])) + math.exp(old_div(-falloff[2], T))
         elif falloff[1] != 0.:
-            Fc = math.exp(-T / falloff[1])
+            Fc = math.exp(old_div(-T, falloff[1]))
         else:
             Fc = falloff[0]
 
-        F = Fc ** (1. / (1. + math.log10(Pr) ** 2))
+        F = Fc ** (old_div(1., (1. + math.log10(Pr) ** 2)))
 
-        K = Kinf * (Pr / (1. + Pr)) * F
+        K = Kinf * (old_div(Pr, (1. + Pr))) * F
 
         return K
 
@@ -483,7 +497,7 @@ class ReactionRate(object):
             direction)
         """
         Kf = cls.p_ratek(T, cM, f_arrlow, f_arrhigh, f_falloff)
-        return Kf / cls.arr_ratek(T, arr)
+        return old_div(Kf, cls.arr_ratek(T, arr))
 
     @classmethod
     def x_ratek(cls, T, cM, arrK0=[0., 0., 0.], arrK2=[0., 0., 0.],
@@ -571,7 +585,7 @@ class ReactionRate(object):
         """
         K1 = cls.arr_ratek(T, arrK1)
         K2 = cls.arr_ratek(T, arrK2)
-        K = (K1 + K2 * cM) * (1. + 1.4e-21 * cH2O * math.exp(2200. / T))
+        K = (K1 + K2 * cM) * (1. + 1.4e-21 * cH2O * math.exp(old_div(2200., T)))
 
     @classmethod
     def a_ratek(cls, T, cM, arrK1=[0., 0., 0.], xcarbon=0.):
@@ -697,7 +711,7 @@ class ReactionRate(object):
         """
         K1 = cls.arr_ratek(T, arrK1)
         K2 = cls.arr_ratek(T, arrK2)
-        return K1 / (1. + K2)
+        return old_div(K1, (1. + K2))
 
     @classmethod
     def g_ratek(cls, T, cO2, arrK1, arrK2):
@@ -723,7 +737,7 @@ class ReactionRate(object):
         """
         K1 = cls.arr_ratek(T, arrK1)
         K2 = cls.arr_ratek(T, arrK2)
-        return K1 / (1. + K2 * cO2)
+        return old_div(K1, (1. + K2 * cO2))
 
     # TODO: built-in function for HOC2H4O ------> HO2 + 2CH2O  (see calcrate.f)
 
@@ -753,12 +767,12 @@ class ReactionRate(object):
         xminf = 8.1
         xf = 0.411
 
-        xxyn = alpha * math.exp(beta * xcarbn) * zdnum * ((300. / T) ** xm0)
-        yyyn = y300 * ((300. / T) ** xminf)
-        aaa = math.log10(xxyn / yyyn)
-        zzyn = 1. / (1. + aaa * aaa)
-        rarb = (xxyn / (1. + (xxyn / yyyn))) * (xf ** zzyn)
-        fyrno3 = rarb / (1. + rarb)
+        xxyn = alpha * math.exp(beta * xcarbn) * zdnum * ((old_div(300., T)) ** xm0)
+        yyyn = y300 * ((old_div(300., T)) ** xminf)
+        aaa = math.log10(old_div(xxyn, yyyn))
+        zzyn = old_div(1., (1. + aaa * aaa))
+        rarb = (old_div(xxyn, (1. + (old_div(xxyn, yyyn))))) * (xf ** zzyn)
+        fyrno3 = old_div(rarb, (1. + rarb))
 
         return fyrno3
 
@@ -916,7 +930,7 @@ class Reaction(object):
         if not isinstance(val, basestring):
             raise TypeError("Bad type for status: expected string, got %s"
                             % type(val).__name__)
-        if val not in self.valid_status.keys():
+        if val not in list(self.valid_status.keys()):
             raise ValueError("Bad value for status: expected one of the "
                              "following capital letters:\n%s"
                              % pprint.pformat(self.valid_status))
@@ -959,12 +973,12 @@ class Reaction(object):
         """
         reac = cls(reac_dict['id'])
         for k in cls.get_attributes():
-            if k not in reac_dict.keys():
+            if k not in list(reac_dict.keys()):
                 warnings.warn("reaction attribute '%s' not in the dictionary, "
                               "default value %s used"
                               % (k, str(getattr(reac, k))))
         reac.flag = reac_dict['flag']   # must be set before rate
-        for k, v in reac_dict.items():
+        for k, v in list(reac_dict.items()):
             setattr(reac, k, v)
         return reac
 
@@ -972,7 +986,7 @@ class Reaction(object):
         """
         Return a :class:`Reaction` object as a python dictionary
         """
-        dict_attr_names = [k for k in self.__dict__.keys() if k[0] != '_']
+        dict_attr_names = [k for k in list(self.__dict__.keys()) if k[0] != '_']
         attr_names = set(dict_attr_names + self.get_attributes())
 
         return {k: getattr(self, k) for k in attr_names}
@@ -983,7 +997,7 @@ class Reaction(object):
         Return a list of the names of the :class:`Reaction` built-in attributes 
         (i.e., properties). 
         """
-        return [k for k, v in cls.__dict__.items() if type(v) == property]
+        return [k for k, v in list(cls.__dict__.items()) if type(v) == property]
 
     def format(self):
         """
@@ -1095,7 +1109,7 @@ class Globchem(object):
         value : int
             default value to assign to each species
         """
-        if group_id in self.mb_groups.keys():
+        if group_id in list(self.mb_groups.keys()):
             raise KeyError("group_id already in mass balance groups")
         if status not in ('A', 'D'):
             raise ValueError("Bad value for status")
@@ -1104,7 +1118,7 @@ class Globchem(object):
 
         self.mb_groups[group_id] = status
 
-        for s in self.species.values():
+        for s in list(self.species.values()):
             s.mb_groups[group_id] = value
 
     def remove_mb_group(self, group_id):
@@ -1116,17 +1130,17 @@ class Globchem(object):
         group_id : string
             mass blance group identifiant
         """
-        if group_id not in self.mb_groups.keys():
+        if group_id not in list(self.mb_groups.keys()):
             raise KeyError("no mass balance group with group_id")
         del self.mb_groups[group_id]
-        for s in self.species.values():
+        for s in list(self.species.values()):
             del s.mb_groups[group_id]
 
     def filter_mb_groups_bystatus(self, status):
         """
         Return a id list with mass balance groups of 'status'   
         """
-        return [k for k, v in self.mb_groups.items() if v == status]
+        return [k for k, v in list(self.mb_groups.items()) if v == status]
 
     def add_species(self, spec):
         """
@@ -1140,7 +1154,7 @@ class Globchem(object):
         def add_one_species(spec1):
             if not isinstance(spec1, Species):
                 raise TypeError("argument is not a Species object")
-            elif spec1.id in self.species.keys():
+            elif spec1.id in list(self.species.keys()):
                 raise KeyError("species with key %s already exists in Globchem"
                            % spec1.id)
             self.species[spec1.id] = spec1
@@ -1173,7 +1187,7 @@ class Globchem(object):
             # update reactions
             for rt, rs in [[self.reac_kn, "kinetic"],
                            [self.reac_ph, "photolysis"]]:
-                reac_list = [k for k, v in rt.items()
+                reac_list = [k for k, v in list(rt.items())
                              if spec1_id in v.reactants
                              or spec1_id in v.products]
                 self.remove_reaction(reac_list, rs)
@@ -1211,13 +1225,13 @@ class Globchem(object):
             new species
         """
         def copy_one_species(spec1_id, new1_id, **kwargs):
-            if spec1_id not in self.species.keys():
+            if spec1_id not in list(self.species.keys()):
                 raise KeyError("Species %s doesn't exist" % spec1_id)
 
             new_spec = copy.deepcopy(self.species[spec1_id])
             new_spec.id = new1_id
-            for k, v in kwargs.items():
-                if k not in new_spec.to_dict().keys():
+            for k, v in list(kwargs.items()):
+                if k not in list(new_spec.to_dict().keys()):
                     raise KeyError("Invalid Species property : %s" % k)
                 setattr(new_spec, k, v)
 
@@ -1226,9 +1240,9 @@ class Globchem(object):
             # update reactions
             for rt, rs in [[self.reac_kn, "kinetic"],
                            [self.reac_ph, "photolysis"]]:
-                reac_list1 = [k for k, v in rt.items()
+                reac_list1 = [k for k, v in list(rt.items())
                               if spec1_id in v.reactants]
-                reac_list2 = [k for k, v in rt.items()
+                reac_list2 = [k for k, v in list(rt.items())
                               if spec1_id in v.products]
                 for k in reac_list1:
                     new_id = k + 0.5
@@ -1244,11 +1258,11 @@ class Globchem(object):
 
         if hasattr(new_id, "__iter__") and not isinstance(new_id, dict):
             # verify and re-arrange kwargs
-            for k, listv in kwargs.items():
+            for k, listv in list(kwargs.items()):
                 if len(listv) != len(new_id):
                     raise ValueError("Invalid value for kwarg '%s'" % k)
-            tp = zip(*([(k, v) for v in listv] for k, listv in kwargs.items()))
-            list_kwargs = map(dict, tp)
+            tp = list(zip(*([(k, v) for v in listv] for k, listv in list(kwargs.items()))))
+            list_kwargs = list(map(dict, tp))
 
             if len(list_kwargs) > 0:
                 for s, kw in zip(new_id, list_kwargs):
@@ -1292,9 +1306,9 @@ class Globchem(object):
         str_fexpr = "fexpr(" + str_list_attr + ")"
 
         if getid:
-            return [id for id, s in self.species.items() if eval(str_fexpr)]
+            return [id for id, s in list(self.species.items()) if eval(str_fexpr)]
         else:
-            return [s for s in self.species.values() if eval(str_fexpr)]
+            return [s for s in list(self.species.values()) if eval(str_fexpr)]
 
     def add_reaction(self, reac, reorder=True):
         """
@@ -1314,13 +1328,13 @@ class Globchem(object):
         """
         def add_one_reaction(reac1):
             if isinstance(reac1, (PhotolysisReaction)):
-                if reac1.id in self.reac_ph.keys():
+                if reac1.id in list(self.reac_ph.keys()):
                     raise KeyError("photolysis reaction with id/key %s already"
                                    " exists in Globchem" % reac1.id)
                 else:
                     self.reac_ph[reac1.id] = reac1
             elif isinstance(reac1, (Reaction, KineticReaction)):
-                if reac1.id in self.reac_kn.keys():
+                if reac1.id in list(self.reac_kn.keys()):
                     raise KeyError("kinetic reaction with id/key %s already "
                                    "exists in Globchem" % reac1.id)
                 else:
@@ -1401,13 +1415,13 @@ class Globchem(object):
             new reaction
         """
         def copy_one_reaction(reac1_id, new1_id, rt, reorder, **kwargs):
-            if reac1_id not in rt.keys():
+            if reac1_id not in list(rt.keys()):
                 raise KeyError("Reaction %s doesn't exist" % spec1_id)
 
             new_reac = copy.deepcopy(rt[reac1_id])
             new_reac.id = new1_id
-            for k, v in kwargs.items():
-                if k not in new_reac.to_dict().keys():
+            for k, v in list(kwargs.items()):
+                if k not in list(new_reac.to_dict().keys()):
                     raise KeyError("Invalid Reaction property : %s" % k)
                 setattr(new_reac, k, v)
 
@@ -1420,11 +1434,11 @@ class Globchem(object):
 
         if hasattr(new_id, "__iter__") and not isinstance(new_id, dict):
             # verify and re-arrange kwargs
-            for k, listv in kwargs.items():
+            for k, listv in list(kwargs.items()):
                 if len(listv) != len(new_id):
                     raise ValueError("Invalid value for kwarg '%s'" % k)
-            tp = zip(*([(k, v) for v in listv] for k, listv in kwargs.items()))
-            list_kwargs = map(dict, tp)
+            tp = list(zip(*([(k, v) for v in listv] for k, listv in list(kwargs.items()))))
+            list_kwargs = list(map(dict, tp))
 
             if len(list_kwargs) > 0:
                 for r, kw in zip(new_id, list_kwargs):
@@ -1473,9 +1487,9 @@ class Globchem(object):
             rt = self.reac_ph
 
         if getid:
-            return [id for id, s in rt.items() if eval(str_fexpr)]
+            return [id for id, s in list(rt.items()) if eval(str_fexpr)]
         else:
-            return [s for s in rt.values() if eval(str_fexpr)]
+            return [s for s in list(rt.values()) if eval(str_fexpr)]
 
     def _reorder_reactions(self):
         """
@@ -1515,11 +1529,11 @@ class Globchem(object):
         gc.filename_dat = filename
         gc.description = header
         gc.mb_groups = mb_groups
-        gc.add_species((Species.from_dict(s) for s in species.values()))
+        gc.add_species((Species.from_dict(s) for s in list(species.values())))
         gc.add_reaction((KineticReaction.from_dict(rkn)
-                         for rkn in reac_kn.values()))
+                         for rkn in list(reac_kn.values())))
         gc.add_reaction((PhotolysisReaction.from_dict(rph)
-                         for rph in reac_ph.values()))
+                         for rph in list(reac_ph.values())))
 
         # TODO: add photolysis reactions
 

--- a/pygchem/globchem.py
+++ b/pygchem/globchem.py
@@ -894,7 +894,7 @@ class Reaction(object):
         return self._rate
     @rate.setter
     def rate(self, val):
-        if isinstance(val, (ReactionRate, types.NoneType)):
+        if isinstance(val, (ReactionRate, type(None))):
             self._rate = val
         elif isinstance(val, dict):
             ratef = ReactionRate.get_ratef_fromflag(self.flag)

--- a/pygchem/grid.py
+++ b/pygchem/grid.py
@@ -18,7 +18,17 @@ It provides default grid specification for various models and allows to easily
 get grid coordinates. User-specific grids can also be defined.
 
 """
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import hex
+from builtins import object
+from past.utils import old_div
 import numpy as np
 
 from pygchem.tools import atm, gridspec
@@ -116,7 +126,7 @@ class CTMGrid(object):
         self._altitude_edges = None
         self._altitude_centers = None
 
-        for k, v in kwargs.items():
+        for k, v in list(kwargs.items()):
             self.__setattr__(k, v)
 
     @classmethod
@@ -153,7 +163,7 @@ class CTMGrid(object):
         """
         settings = gridspec.get_model_info(model_name)
         model = settings.pop('model_name')
-        for k, v in kwargs.items():
+        for k, v in list(kwargs.items()):
             if k in ('resolution', 'Psurf'):
                 settings[k] = v
 
@@ -235,8 +245,8 @@ class CTMGrid(object):
         rlon = self.resolution[0]
         rlat = self.resolution[1]
 
-        Nlon = int(360. / rlon)
-        Nlat = int(180. / rlat) + self.halfpolar
+        Nlon = int(old_div(360., rlon))
+        Nlat = int(old_div(180., rlat)) + self.halfpolar
 
         elon = np.arange(Nlon + 1) * rlon - np.array(180.)
         elon -= rlon / 2. * self.center180
@@ -245,14 +255,14 @@ class CTMGrid(object):
         elat[0] = -90.
         elat[-1] = 90.
 
-        clon = (elon - rlon / 2.)[1:]
+        clon = (elon - old_div(rlon, 2.))[1:]
         clat = np.arange(Nlat) * rlat - np.array(90.)
 
         if self.halfpolar:                        # Fix grid boundaries
-            clat[0] = (elat[0] + elat[1]) / 2.
+            clat[0] = old_div((elat[0] + elat[1]), 2.)
             clat[-1] = - clat[0]
         else:
-            clat += (elat[1] - elat[0]) / 2.
+            clat += old_div((elat[1] - elat[0]), 2.)
 
         self._lonlat_centers = (clon, clat)
         self._lonlat_edges = (elon, elat)
@@ -546,8 +556,8 @@ class CTMGrid(object):
         Pc = 0.5 * (Pe[0:-1] + Pe[1:])
 
         if self.hybrid:
-            ETAe = (Pe - Ptop) / (Psurf - Ptop)
-            ETAc = (Pc - Ptop) / (Psurf - Ptop)
+            ETAe = old_div((Pe - Ptop), (Psurf - Ptop))
+            ETAc = old_div((Pc - Ptop), (Psurf - Ptop))
         else:
             SIGe = SIGe * np.ones_like(Psurf)
             SIGc = SIGc * np.ones_like(Psurf)

--- a/pygchem/io/__init__.py
+++ b/pygchem/io/__init__.py
@@ -11,5 +11,12 @@ Read/write GEOS-Chem files (input or output) into/from Python built-in
 data structures.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 __all__ = ["globchem", "bpch", "diaginfo"]

--- a/pygchem/io/__init__.py
+++ b/pygchem/io/__init__.py
@@ -19,4 +19,7 @@ from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
 from builtins import *
+
 __all__ = ["globchem", "bpch", "diaginfo"]
+
+from . bpch import bpch_file, read_bpch

--- a/pygchem/io/bpch.py
+++ b/pygchem/io/bpch.py
@@ -148,7 +148,7 @@ class BPCHDataProxyConcatDim(object):
     def data(self):
         if self._data is None:
             if self.memmap:
-                # print("LOAD (memmap)")
+                print("LOAD (memmap)")
                 self._data = self.load_memmap()
             else:
                 # print("LOAD")
@@ -231,7 +231,13 @@ class BPCHDataProxyConcatDim(object):
             # to squeeze the leading dimension
             data = all_data[0][0]
 
-        return self._maybe_maskandscale(data)
+        if self.maskandscale and (self.scale_factor is not None):
+            data = data * self.scale_factor
+
+
+        print(type(data))
+        return data
+
 
 
     def __getitem__(self, keys):

--- a/pygchem/io/bpch.py
+++ b/pygchem/io/bpch.py
@@ -83,6 +83,23 @@ class BPCHDataProxy(object):
             data = np.concatenate(all_data, axis=self.concat_axis)
         return data * self.scale_factor
 
+    def load_memmap(self):
+        """ Create a memory-map into the file proxied by this instance.
+
+        note: we offset the file position by 4 bytes to account for the
+              prefix that that the Fortran write statement prepends to an
+              output line.
+        """
+        print(self.shape)
+        all_data = np.empty(self.shape)
+        for i, pos in enumerate(self.file_positions):
+            data = np.memmap(self.path, mode='r',
+                             dtype=np.dtype(self.endian+'f4'),
+                             offset=pos+4, shape=self._shape, order='F')
+            all_data[i,...] = data
+        return all_data * self.scale_factor
+
+
     def __getitem__(self, keys):
         return self.data[keys]
 

--- a/pygchem/io/bpch.py
+++ b/pygchem/io/bpch.py
@@ -182,6 +182,7 @@ class BPCHDataProxy(object):
             setattr(self, key, value)
 
 
+# TODO: Incremental read mode?
 def read_bpch(filename, mode='rb', skip_data=True,
               diaginfo_file='', tracerinfo_file='',
               dummy_prefix_dims=0, concat_blocks=False, first_header=False,

--- a/pygchem/io/bpch.py
+++ b/pygchem/io/bpch.py
@@ -10,7 +10,16 @@
 Read / write binary punch (BPCH) files.
 
 """
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from past.utils import old_div
+from builtins import object
 import os
 
 import numpy as np
@@ -74,7 +83,7 @@ class BPCHDataProxy(object):
         return {attr: getattr(self, attr) for attr in self.__slots__}
 
     def __setstate__(self, state):
-        for key, value in state.iteritems():
+        for key, value in list(state.items()):
             setattr(self, key, value)
 
 
@@ -247,7 +256,7 @@ def append_bpch(bpch_file, datablock):
 
     """
     if isinstance(datablock['data'], BPCHDataProxy):
-        data = datablock['data'].data / datablock['data'].scale_factor
+        data = old_div(datablock['data'].data, datablock['data'].scale_factor)
     else:
         data = datablock['data']
 

--- a/pygchem/io/bpch.py
+++ b/pygchem/io/bpch.py
@@ -89,7 +89,7 @@ class BPCHDataProxy(object):
     def __repr__(self):
         fmt = '<{self.__class__.__name__} shape={self.shape}' \
               ' dtype={self.dtype!r} path={self.path!r}' \
-              ' file_position={self.file_position}' \
+              ' file_positions={self.file_positions}' \
               ' scale_factor={self.scale_factor}>'
         return fmt.format(self=self)
 

--- a/pygchem/io/bpch.py
+++ b/pygchem/io/bpch.py
@@ -20,7 +20,10 @@ standard_library.install_aliases()
 from builtins import *
 from past.utils import old_div
 from builtins import object
+from collections import OrderedDict
+import mmap as mm
 import os
+import warnings
 
 import numpy as np
 from dask import delayed
@@ -38,6 +41,73 @@ ND49_TITLE = "GEOS-CHEM DIAG49 instantaneous timeseries"
 
 
 class BPCHDataProxy(object):
+    """A reference to the data payload of a single BPCH file datablock."""
+
+    # __slots__ = ('_shape', 'dtype', 'path', 'endian', 'file_position',
+    #              'scale_factor', 'fill_value', 'maskandscale', '_data')
+
+    def __init__(self, shape, dtype, path, endian, file_position,
+                 scale_factor, fill_value, maskandscale):
+        self._shape = shape
+        self.dtype = dtype
+        self.path = path
+        self.fill_value = fill_value
+        self.endian = endian
+        self.file_position = file_position
+        self.scale_factor = scale_factor
+        self.maskandscale = maskandscale
+        self._data = None
+
+    def _maybe_mask_and_scale(self, arr):
+        if self.maskandscale and (self.scale_factor is not None):
+            arr = self.scale_factor * arr
+        return arr
+
+    @property
+    def shape(self):
+        return self._shape
+
+    @property
+    def ndim(self):
+        return len(self.shape)
+
+    @property
+    def data(self):
+        if self._data is None:
+            self._data = self.load()
+        return self._data
+
+    def array(self):
+        return self.data
+
+    def load(self):
+        with uff.FortranFile(self.path, 'rb', self.endian) as bpch_file:
+            pos = self.file_position
+            bpch_file.seek(pos)
+            data = np.array(bpch_file.readline('*f'))
+            data = data.reshape(self._shape, order='F')
+        if self.maskandscale and (self.scale_factor is not None):
+            data = data * self.scale_factor
+        return data
+
+    def __getitem__(self, keys):
+        return self.data[keys]
+
+    def __repr__(self):
+        fmt = '<{self.__class__.__name__} shape={self.shape}' \
+              ' dtype={self.dtype!r} path={self.path!r}' \
+              ' file_position={self.file_position}' \
+              ' scale_factor={self.scale_factor}>'
+        return fmt.format(self=self)
+
+    def __getstate__(self):
+        return {attr: getattr(self, attr) for attr in self.__slots__}
+
+    def __setstate__(self, state):
+        for key, value in list(state.items()):
+            setattr(self, key, value)
+
+class BPCHDataProxyConcatDim(object):
     """A reference to the data payload of a single BPCH file datablock."""
 
     __slots__ = ('_shape', 'dtype', 'path', 'endian', 'file_positions',
@@ -182,6 +252,298 @@ class BPCHDataProxy(object):
             setattr(self, key, value)
 
 
+class bpch_variable(BPCHDataProxy):
+
+    def __init__(self, data_pieces, *args, attributes=None,
+                 **kwargs):
+        self._data_pieces = data_pieces
+        super(bpch_variable, self).__init__(*args, **kwargs)
+
+        if attributes is not None:
+            self._attributes = attributes
+        else:
+            self._attributes = OrderedDict()
+        for k, v in self._attributes.items():
+            self.__dict__[k] = v
+
+    def load(self):
+        warnings.warn("'load' disabled on bpch_variable.")
+        pass
+
+    @property
+    def shape(self):
+        shape_copy = list(self._shape)
+        shape_copy[0] = len(self._data_pieces)
+        return tuple(shape_copy)
+
+    @property
+    def chunks(self):
+        return len(self._data_pieces)
+
+    @property
+    def data(self):
+        arr = np.concatenate(self._data_pieces, axis=0).view(self.dtype)
+        return self._maybe_mask_and_scale(arr)
+
+    def __setattr__(self, key, value):
+        try:
+            self._attribute[key] = value
+        except AttributeError:
+            pass
+        self.__dict__[key] = value
+
+    def __str__(self):
+        pass
+
+    def __repr__(self):
+        return """
+          <{self.__class__.__name__}
+          shape={self.shape} (chunks={self.chunks})
+           dtype={self.dtype!r} scale_factor={self.scale_factor}>
+        """.format(self=self)
+
+    def __getitem__(self, index):
+        if self.chunks == 1:
+            arr = self._data_pieces[0][index]
+        else:
+            pass
+
+        return self._maybe_mask_and_scale(arr)
+
+class bpch_file(object):
+    """ A file object for BPCH data on disk.
+
+    Parameters
+    ----------
+
+    Notes
+    -----
+
+    Examples
+    --------
+
+    """
+
+    def __init__(self, filename, mode='rb', endian='>', memmap=False,
+                 diaginfo_file='', tracerinfo_file='',
+                 maskandscale=False):
+        """ Initialize a bpch_file. """
+
+        self.mode = mode
+        if not mode.startswith('r'):
+            raise ValueError("Currently only know how to 'r(b)'ead bpch files.")
+
+        self.filename = filename
+        self.fsize = os.path.getsize(self.filename)
+        self.use_mmap = memmap
+        self.endian = endian
+
+        # Open a pointer to the file
+        self.fp = uff.FortranFile(self.filename, self.mode, self.endian)
+
+        # self._mm = None
+        # self._mm_buf = None
+        # if self.use_mmap:
+        #     self._mm = mm.mmap(self.fp.fileno(), 0, access=mm.ACCESS_READ)
+        #     self._mm_buf = np.frombuffer(self._mm, dtype=np.int8)
+
+        dir_path = os.path.abspath(os.path.dirname(filename))
+        if not dir_path:
+            dir_path = os.getcwd()
+        if not tracerinfo_file:
+            tracerinfo_file = os.path.join(dir_path, "tracerinfo.dat")
+            if not os.path.exists(tracerinfo_file):
+                tracerinfo_file = ''
+        self.tracerinfo_file = tracerinfo_file
+        if not diaginfo_file:
+            diaginfo_file = os.path.join(dir_path, "diaginfo.dat")
+            if not os.path.exists(diaginfo_file):
+                diaginfo_file = ''
+        self.diaginfo_file = diaginfo_file
+        self.ctm_info = CTMDiagnosticInfo(diaginfo_file=self.diaginfo_file,
+                                          tracerinfo_file=self.tracerinfo_file)
+
+        # self.dimensions = OrderedDict()
+        self.variables = OrderedDict()
+        self.times = []
+        self.time_bnds = []
+
+        self._attributes = OrderedDict()
+
+        # Critical information for accessing file contents
+        self.maskandscale = maskandscale
+        self._header_pos = None
+
+        if mode.startswith('r'):
+            self._read()
+
+
+    def close(self):
+        """ Close this bpch file. """
+        import weakref
+        import warnings
+
+        if not self.fp.closed:
+            self.variables = OrderedDict()
+
+            # if self._mm_buf is not None:
+            #     ref = weakref.ref(self._mm_buf)
+            #     self._mm_buf = None
+            #     if ref() is None:
+            #         self._mm.close()
+            #     else:
+            #         warnings.warn(
+            #             "Can't close bpch_file opened with memory mapping until "
+            #             "all of variables/arrays referencing its data are "
+            #             "copied and/or cleaned", category=RuntimeWarning)
+            # self._mm = None
+            self.fp.close()
+    # __del__ = close
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
+    def _read(self):
+        """ Parse the file on disk and set up easy access to meta-
+        and data blocks """
+
+        self._read_metadata()
+        self._read_header()
+        self._read_var_data()
+
+
+    def _read_metadata(self):
+        """ Read the main metadata packaged within a bpch file """
+
+        filetype = self.fp.readline().strip()
+        filetitle = self.fp.readline().strip()
+
+        self.__setattr__('filetype', filetype)
+        self.__setattr__('filetitle', filetitle)
+
+
+    def _read_header(self, all_info=False):
+
+        self._header_pos = self.fp.tell()
+
+        line = self.fp.readline('20sffii')
+        modelname, res0, res1, halfpolar, center180 = line
+        self._attributes.update({
+            "modelname": modelname,
+            "halfpolar": halfpolar,
+            "center180": center180,
+            "res": (res0, res1)
+        })
+        self.__setattr__('modelname', modelname)
+        self.__setattr__('res', (res0, res1))
+        self.__setattr__('halfpolar', halfpolar)
+        self.__setattr__('center180', center180)
+
+        # Re-wind the file
+        self.fp.seek(self._header_pos)
+
+
+    def _read_var_data(self):
+
+        var_bundles = OrderedDict()
+        var_attrs = OrderedDict()
+        _times = []
+
+        while self.fp.tell() < self.fsize:
+
+            var_attr = OrderedDict()
+
+            # read first and second header lines
+            line = self.fp.readline('20sffii')
+            modelname, res0, res1, halfpolar, center180 = line
+
+            line = self.fp.readline('40si40sdd40s7i')
+            category_name, number, unit, tau0, tau1, reserved = line[:6]
+            dim0, dim1, dim2, dim3, dim4, dim5, skip = line[6:]
+            var_attr['number'] = number
+
+            # Decode byte-strings to utf-8
+            category_name = str(category_name, 'utf-8')
+            var_attr['category'] = category_name.strip()
+            unit = str(unit, 'utf-8')
+
+            # get additional metadata from tracerinfo / diaginfo
+            try:
+                cat = self.ctm_info.categories.select_item(
+                    category_name.strip())
+                cat_attr = cat.to_dict()
+                diag = self.ctm_info.diagnostics.select_item(
+                    cat.offset + int(number)
+                )
+                diag_attr = diag.to_dict()
+                if not unit.strip():  # unit may be empty in bpch
+                    unit = diag_attr['unit']  # but not in tracerinfo
+                var_attr.update(diag_attr)
+            except exceptions.SelectionMismatchError:
+                diag = {'name': '', 'scale': 1}
+                var_attr.update(diag)
+                diag_attr = {}
+                cat_attr = {}
+            var_attr['unit'] = unit
+
+            vname = diag['name']
+            fullname = category_name.strip() + "_" + vname
+            # print(fullname)
+
+            # parse metadata, get data or set a data proxy
+            if dim2 == 1:
+                data_shape = (dim0, dim1)         # 2D field
+            else:
+                data_shape = (dim0, dim1, dim2)
+            # Add proxy time dimension to shape
+            data_shape = tuple([1, ] + list(data_shape))
+            origin = (dim3, dim4, dim5)
+            var_attr['origin'] = origin
+
+            pos = self.fp.tell()
+
+            # Map or read the data
+            if self.use_mmap:
+                dtype = np.dtype(self.endian + 'f4')
+                offset = pos + 4
+
+                data = np.memmap(self.filename, mode='r',
+                                 shape=np.product(data_shape),
+                                 dtype=dtype, offset=offset, order='F')
+                # print(len(data), data_shape, np.product(data_shape))
+                data.shape = data_shape
+                self.fp.skipline()
+            else:
+                self.fp.seek(pos)
+                data = np.array(self.fp.readline('*f'))
+                # data = data.reshape(data_shape, order='F')
+                data.shape = data_shape
+            # Save the data as a "bundle" for concatenating in the final step
+            if fullname in var_bundles:
+                var_bundles[fullname].append(data)
+            else:
+                var_bundles[fullname] = [data, ]
+                var_attrs[fullname] = var_attr
+
+            timelo, timehi = timeutil.tau2time(tau0), timeutil.tau2time(tau1)
+            _times.append((timelo, timehi))
+
+        # Copy over the data we've recorded
+        self.time_bnds[:] = _times
+        self.times = [t[0] for t in _times]
+
+        for fullname, bundle in var_bundles.items():
+            var_attr = var_attrs[fullname]
+            self.variables[fullname] = bpch_variable(
+                bundle, data_shape, np.dtype('f'), self.filename, self.endian,
+                file_position=None, scale_factor=var_attr['scale'],
+                fill_value=np.nan, maskandscale=False, attributes=var_attr
+            )
+
+
 # TODO: Incremental read mode?
 def read_bpch(filename, mode='rb', skip_data=True,
               diaginfo_file='', tracerinfo_file='',
@@ -324,10 +686,12 @@ def read_bpch(filename, mode='rb', skip_data=True,
                     )
                     continue
                 else:
-                    data = BPCHDataProxy(data_shape, np.dtype('f'),
-                                         from_file, bpch_file.endian,
-                                         [file_position, ], concat_axis, diag['scale'], np.nan, maskandscale,
-                                         memmap=memmap, use_dask=use_dask)
+                    data = BPCHDataProxyConcatDim(
+                        data_shape, np.dtype('f'),
+                        from_file, bpch_file.endian,
+                        [file_position, ], concat_axis, diag['scale'], np.nan, maskandscale,
+                        memmap=memmap, use_dask=use_dask
+                    )
             else:
                 # TODO: Converting the BPCHDataProxy to record multiple file
                 #       positions breaks the symmetry with load-on-read below,
@@ -457,3 +821,6 @@ def write_bpch(filename, datablocks, title=DEFAULT_TITLE,
     with create_bpch(filename, title, filetype, **kwargs) as bpch_file:
         for db in datablocks:
             append_bpch(bpch_file, db)
+
+
+BPCHFile = bpch_file

--- a/pygchem/io/bpch.py
+++ b/pygchem/io/bpch.py
@@ -148,7 +148,7 @@ class BPCHDataProxyConcatDim(object):
     def data(self):
         if self._data is None:
             if self.memmap:
-                print("LOAD (memmap)")
+                # print("LOAD (memmap)")
                 self._data = self.load_memmap()
             else:
                 # print("LOAD")
@@ -234,8 +234,6 @@ class BPCHDataProxyConcatDim(object):
         if self.maskandscale and (self.scale_factor is not None):
             data = data * self.scale_factor
 
-
-        print(type(data))
         return data
 
 

--- a/pygchem/io/bpch.py
+++ b/pygchem/io/bpch.py
@@ -40,8 +40,8 @@ ND49_TITLE = "GEOS-CHEM DIAG49 instantaneous timeseries"
 class BPCHDataProxy(object):
     """A reference to the data payload of a single BPCH file datablock."""
 
-    __slots__ = ('_shape', 'dtype', 'path', 'endian', 'file_positions',
-                 'concat_axis', 'scale_factor', 'fill_value', 'maskandscale', 'memmap', '_data')
+    # __slots__ = ('_shape', 'dtype', 'path', 'endian', 'file_positions',
+    #              'concat_axis', 'scale_factor', 'fill_value', 'maskandscale', 'memmap', '_data')
 
     # TODO: Re-factor assuming "concat_axis" is just a prepend option
     def __init__(self, shape, dtype, path, endian, file_positions,

--- a/pygchem/io/bpch.py
+++ b/pygchem/io/bpch.py
@@ -159,6 +159,10 @@ def read_bpch(filename, mode='rb', skip_data=True,
             category_name, number, unit, tau0, tau1, reserved = line[:6]
             dim0, dim1, dim2, dim3, dim4, dim5, skip = line[6:]
 
+            # Decode byte-strings to utf-8
+            category_name = str(category_name, 'utf-8')
+            unit = str(unit, 'utf-8')
+
             # get additional metadata from tracerinfo / diaginfo
             try:
                 cat = ctm_info.categories.select_item(category_name.strip())

--- a/pygchem/io/bpch.py
+++ b/pygchem/io/bpch.py
@@ -85,6 +85,11 @@ class BPCHDataProxy(object):
                 self._data = self.load()
         return self._data
 
+    def _maybe_maskandscale(self, arr):
+        if self.maskandscale and (self.scale_factor is not None):
+            return arr * self.scale_factor
+        return arr
+
     def array(self):
         return self.data
 
@@ -116,9 +121,7 @@ class BPCHDataProxy(object):
             # else:
             #     data = np.concatenate(all_data, axis=self.concat_axis)
 
-        if self.maskandscale and (self.scale_factor is not None):
-            data = data * self.scale_factor
-        return data
+        return self._maybe_maskandscale(data)
 
 
     def load_memmap(self):
@@ -128,7 +131,7 @@ class BPCHDataProxy(object):
               prefix that that the Fortran write statement prepends to an
               output line.
         """
-        # print("LOAD_MEMMAP", self.shape)
+        print("LOAD_MEMMAP", self.shape)
         # all_data = np.empty(self.shape)
         all_data = []
         for i, pos in enumerate(self.file_positions):
@@ -158,10 +161,7 @@ class BPCHDataProxy(object):
             # to squeeze the leading dimension
             data = all_data[0][0]
 
-        if self.maskandscale and (self.scale_factor is not None):
-            data = data * self.scale_factor
-
-        return data
+        return self._maybe_maskandscale(data)
 
 
     def __getitem__(self, keys):

--- a/pygchem/io/bpch.py
+++ b/pygchem/io/bpch.py
@@ -93,7 +93,11 @@ class BPCHDataProxy(object):
                 data = data.reshape(self._shape, order='F')
                 all_data.append(data)
             data = np.concatenate(all_data, axis=self.concat_axis)
-        return data# * self.scale_factor
+
+        if self.maskandscale and (self.scale_factor is not None):
+            data = data * self.scale_factor
+        return data
+
 
     def load_memmap(self):
         """ Create a memory-map into the file proxied by this instance.
@@ -113,17 +117,15 @@ class BPCHDataProxy(object):
             )
             all_data.append(dsa.from_delayed(data, self._shape, self.dtype))
         all_data = dsa.concatenate(all_data)
-        return all_data# * self.scale_factor
+
+        if self.maskandscale and (self.scale_factor is not None):
+            all_data = all_data * self.scale_factor
+        return all_data
 
 
     def __getitem__(self, keys):
 
-        if not self.maskandscale:
-            return self.data[keys]
-
-        data = self.data[keys].copy()
-        if self.scale_factor is not None:
-            data = data * self.scale_factor
+        return self.data[keys]
 
         return data
 

--- a/pygchem/io/diaginfo.py
+++ b/pygchem/io/diaginfo.py
@@ -11,7 +11,14 @@ Read / write 'diaginfo.dat' and 'tracerinfo.dat' files (GEOS-Chem diagnostics
 metadata).
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from pygchem.utils.tff import read_fmt_file, write_fmt_file
 
 DIAGINFO_FMT = (

--- a/pygchem/io/globchem.py
+++ b/pygchem/io/globchem.py
@@ -22,7 +22,19 @@ defined in the :module:`pygchem.glochem` module.
 
 External dependencies: fortranformat, sqlite3
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import filter
+from builtins import str
+from builtins import zip
+from builtins import range
+from past.builtins import basestring
 import os
 import collections
 
@@ -102,7 +114,7 @@ def read_globchem_dat(filename):
         species_item['init_concentration'] = [float(i) for i in
                                             species_item['init_concentration']]
         mb_vals = [int(i) for i in species_item['mb_groups']]
-        species_item['mb_groups'] = dict(zip(mb_groups.keys(), mb_vals))
+        species_item['mb_groups'] = dict(list(zip(list(mb_groups.keys()), mb_vals)))
 
     def trim_rlist(reac_list):
         """
@@ -111,7 +123,7 @@ def read_globchem_dat(filename):
         """
         # filter below permits to take only items that are not '' (if string)
         # or 0 (if int or float) because bool('') and bool(0) both return False
-        return filter(bool, reac_list)
+        return list(filter(bool, reac_list))
 
     def read_reac(globchem_file, fline):
         """
@@ -179,8 +191,8 @@ def read_globchem_dat(filename):
 
         # read reaction rate parameters
         n_addrates = reac_row1.pop(5)
-        reac_rates = dict(zip(reac_rates_keys,
-                              reac_row1[2:5] + reac_row1[6:9]))
+        reac_rates = dict(list(zip(reac_rates_keys,
+                              reac_row1[2:5] + reac_row1[6:9])))
         if(n_addrates > 0):
             for i in range(0, n_addrates):
                 new_keys = [s + str(i + 1) for s in reac_rates_keys]
@@ -188,13 +200,13 @@ def read_globchem_dat(filename):
                 fline += 1
                 reac_row2 = reac_r2_fmt.read(l_globchem)
                 del reac_row2[3]  # remove slot for number of rate coef lines
-                reac_rates.update(dict(zip(new_keys, reac_row2)))
+                reac_rates.update(dict(list(zip(new_keys, reac_row2))))
 
         # re-arrange rate parameters using corr_ratep
         reac_flag = reac_item[3].upper()
         mod_reac_rates = dict()
         if reac_flag in mod_ratep:
-            for k, v in mod_ratep[reac_flag].items():
+            for k, v in list(mod_ratep[reac_flag].items()):
                 if (isinstance(v, collections.Iterable)
                     and not isinstance(v, basestring)):
                     mod_reac_rates[k] = [reac_rates[n] for n in v]
@@ -216,8 +228,8 @@ def read_globchem_dat(filename):
         if(reac_eq[-2] is None):
             reac_eq[-2] = 0.0
 
-        reac_item.append(trim_rlist([reac_eq[i] for i in xrange(1, 13, 3)]))
-        reac_item.append(trim_rlist([reac_eq[i] for i in xrange(13, 61, 3)]))
+        reac_item.append(trim_rlist([reac_eq[i] for i in range(1, 13, 3)]))
+        reac_item.append(trim_rlist([reac_eq[i] for i in range(13, 61, 3)]))
         reac_item.append(trim_rlist([reac_eq[i] for i in range(12, 60, 3)]))
 
         return reac_item
@@ -236,7 +248,7 @@ def read_globchem_dat(filename):
         row = [s.strip() for s in row]
         species_info[row[0]] = row[1:]
     f_species_dat.close()
-    species_info_blank = ['' for s in xrange(0, len(species_info.keys()[0]))]
+    species_info_blank = ['' for s in range(0, len(list(species_info.keys())[0]))]
 
     # globchem.dat file
     globchem_file = open(filename, "r")
@@ -258,7 +270,7 @@ def read_globchem_dat(filename):
     l_globchem = globchem_file.readline()
     mb_st = sanatize_str_inlist(species_mb_st_fmt.read(l_globchem))
 
-    mb_groups = dict(zip(mb_id, mb_st))
+    mb_groups = dict(list(zip(mb_id, mb_st)))
     fline += 2
 
     species_r1_fmt = FortranRecordReader('(A1,1X,A14,A2,1X,0PF6.2,4(1PE10.3))')
@@ -278,7 +290,7 @@ def read_globchem_dat(filename):
         except KeyError:
             species_vals += species_info_blank
 
-        species[species_this_key] = dict(zip(species_keys, species_vals))
+        species[species_this_key] = dict(list(zip(species_keys, species_vals)))
         convert_species_item(species[species_this_key], mb_groups)
         del species_vals
         n_species += 1
@@ -301,7 +313,7 @@ def read_globchem_dat(filename):
             elif reac_flag == 'E':
                 reac_vals[5].update(mem_p_ratep)
 
-            reac_kn[n_reac] = dict(zip(reac_keys, reac_vals))
+            reac_kn[n_reac] = dict(list(zip(reac_keys, reac_vals)))
             reac_kn[n_reac]['id'] = n_reac
             n_reac += 1
         del reac_vals
@@ -313,14 +325,14 @@ def read_globchem_dat(filename):
         if(reac_vals == "end"):
             break
         else:
-            reac_ph[n_reac] = dict(zip(reac_keys, reac_vals))
+            reac_ph[n_reac] = dict(list(zip(reac_keys, reac_vals)))
             reac_ph[n_reac]['id'] = n_reac
             n_reac += 1
         del reac_vals
 
     # identify links between species (through reactions): parse reac_kn
     link_id = 0
-    for reac_key, reac_vals in reac_kn.iteritems():
+    for reac_key, reac_vals in list(reac_kn.items()):
         for reactant in reac_vals['reactants']:
             if(reactant != '' and reactant != 'M'):
                 for product in reac_vals['products']:

--- a/pygchem/io/hemco.py
+++ b/pygchem/io/hemco.py
@@ -10,7 +10,16 @@
 Read / Write Harvard-NASA Emissions Component (HEMCO) settings files.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import zip
+from builtins import str
 import re
 import itertools
 from types import StringTypes
@@ -156,7 +165,7 @@ def _get_sections_lines(filename):
                 continue
             if 'BEGIN SECTION' in line:
                 section = line.replace('BEGIN SECTION ', '')
-                if not section in lines.keys():
+                if not section in list(lines.keys()):
                     lines[section] = []
                 continue
             if 'END SECTION' in line:

--- a/pygchem/tools/__init__.py
+++ b/pygchem/tools/__init__.py
@@ -14,5 +14,12 @@ This acts as a toolbox gathering miscellaneous functions organized in several
 modules depending on their usage or their external dependencies.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 __all__ = ['atm', 'ctm2cf', 'gridspec', 'irisutil', 'timeutil']

--- a/pygchem/tools/atm.py
+++ b/pygchem/tools/atm.py
@@ -15,8 +15,15 @@
 This module contains routines related to atmospheric science.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import numpy as np
 
 

--- a/pygchem/tools/ctm2cf.py
+++ b/pygchem/tools/ctm2cf.py
@@ -40,12 +40,12 @@ UNITS_MAP_CTM2CF = (
     ('atoms C', 'count'),
     ('ppbC', 'ppb'),        # prefix or suffix required (nb. of carbon atoms)
     ('kg C', 'kg'),         # prefix or suffix required (?)
-    ('molC', 'mol'),        # prefix or suffix required ?     TODO: 
+    ('molC', 'mol'),        # prefix or suffix required ?     TODO:
     ('gC', 'g'),            # prefix or suffix required ?
     ('kg S', 'kg'),
     ('kg OH', 'kg'),
     ('kg NO3', 'kg'),
-    ('kg H2O2', 'kg'), 
+    ('kg H2O2', 'kg'),
     ('unitless', '1'),
     ('unitles', '1'),       # typo found in tracerinfo or diaginfo
     ('v/v', '1'),
@@ -60,14 +60,14 @@ UNITS_MAP_CTM2CF = (
     ('deg C', 'Celsius'),
     ('C', 'Celsius'),
     ('mm/da', 'mm/day'),    # typo in tracerinfo.dat 4/17/12
-    ('kg/m2/', 'kg/m2'))    # ?? (tracerinfo.dat 6801 (line 1075)             
+    ('kg/m2/', 'kg/m2'))    # ?? (tracerinfo.dat 6801 (line 1075)
 
 
 def get_cfcompliant_units(units, prefix='', suffix=''):
     """
     Get equivalent units that are compatible with the udunits2 library
     (thus CF-compliant).
-    
+
     Parameters
     ----------
     units : string
@@ -78,21 +78,21 @@ def get_cfcompliant_units(units, prefix='', suffix=''):
     suffix : string
         Will be added at the end of the returned string
         (must be a valid udunits2 expression).
-    
+
     Returns
     -------
     A string representation of the conforming units.
-    
+
     References
     ----------
     The udunits2 package : http://www.unidata.ucar.edu/software/udunits/
-    
+
     Notes
     -----
     This function only relies on the table stored in :attr:`UNITS_MAP_CTM2CF`.
     Therefore, the units string returned by this function is not certified to
     be compatible with udunits2.
-    
+
     Examples
     --------
     >>> get_cfcompliant_units('molec/cm2')
@@ -101,13 +101,13 @@ def get_cfcompliant_units(units, prefix='', suffix=''):
     '1'
     >>> get_cfcompliant_units('ppbC', prefix='3')
     '3ppb
-    
+
     """
     compliant_units = units
-    
+
     for gcunits, udunits in UNITS_MAP_CTM2CF:
-        compliant_units = string.replace(compliant_units, gcunits, udunits)
-    
+        compliant_units = str.replace(compliant_units, gcunits, udunits)
+
     return prefix + compliant_units + suffix
 
 

--- a/pygchem/tools/ctm2cf.py
+++ b/pygchem/tools/ctm2cf.py
@@ -16,7 +16,14 @@ References:
     December, 2011.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import string
 
 from pygchem.tools import timeutil

--- a/pygchem/tools/gridspec.py
+++ b/pygchem/tools/gridspec.py
@@ -33,7 +33,15 @@ See Also
     provides a more complete API for handling grids used by GEOS-Chem.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import zip
 import re
 import itertools
 
@@ -543,11 +551,10 @@ def get_model_info(model_name):
     gen_seps = itertools.combinations_with_replacement(
         sep_chars, len(split_name) - 1
     )
-    test_names = ("".join((n for n in itertools.chain(*zip(split_name,
-                                                           s + ('',)))))
+    test_names = ("".join((n for n in itertools.chain(*list(zip(split_name,
+                                                           s + ('',))))))
                   for s in gen_seps)
-    match_names = list(filter(lambda name: name in get_supported_models(),
-                              test_names))
+    match_names = list([name for name in test_names if name in get_supported_models()])
 
     if not len(match_names):
         raise ValueError("Model '{0}' is not supported".format(model_name))

--- a/pygchem/tools/irisutil.py
+++ b/pygchem/tools/irisutil.py
@@ -10,7 +10,16 @@
 A bunch of utility functions based on the SciTools's Iris package.
 
 """
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import range
+from past.utils import old_div
 import collections
 import warnings
 from types import StringTypes
@@ -365,7 +374,7 @@ def fix_cube_attributes_vals(cube):
 
     Convert it to int.
     """
-    for key, val in cube.attributes.items():
+    for key, val in list(cube.attributes.items()):
         if type(val) == bool:
             cube.attributes[key] = int(val)
 
@@ -434,7 +443,7 @@ def ppbC_2_ppbv(cube):
 
     if is_hydrocarbon and is_ppbc:
         carbon_weight = cube.attributes.get('carbon_weight')
-        cube.data = cube.data / carbon_weight
+        cube.data = old_div(cube.data, carbon_weight)
         cube.units = 'ppbv'
 
 
@@ -806,7 +815,7 @@ def get_altitude_coord(gridbox_heights, topography):
                      base_level_altitude)
     altitude_lbnd = altitude_ubnd - gridbox_heights.data
     altitude_lbnd[..., 1:] = altitude_ubnd[..., :-1]  # force contiguous bounds
-    altitude_points = (altitude_lbnd + altitude_ubnd) / 2.
+    altitude_points = old_div((altitude_lbnd + altitude_ubnd), 2.)
 
     altitude_bounds = np.concatenate((altitude_lbnd[..., np.newaxis],
                                       altitude_ubnd[..., np.newaxis]),
@@ -974,7 +983,7 @@ def compute_cell_volumes(cube, lon_coord='longitude', lat_coord='latitude',
                            volume,
                            long_name=v_long_name,
                            units=out_units),
-                           data_dims=range(0, height_coord.ndim))
+                           data_dims=list(range(0, height_coord.ndim)))
 
 
 def compute_tracer_columns(mixing_ratio, n_air, z_coord,
@@ -1085,7 +1094,7 @@ def _compute_exchange_vertical(src_z_coord, dst_z_coord):
     temp = np.unique(temp)
 
     exchange_z_bounds = np.column_stack((temp[:-1], temp[1:]))
-    exchange_z_points = (exchange_z_bounds[:, 0] + exchange_z_bounds[:, 1]) / 2.
+    exchange_z_points = old_div((exchange_z_bounds[:, 0] + exchange_z_bounds[:, 1]), 2.)
 
     exchange_z_coord = iris.coords.DimCoord(
         exchange_z_points,
@@ -1227,9 +1236,9 @@ def regrid_conservative_vertical(src_cube, dst_grid_cube,
     # compute interpolation weights and data values
     # on the exchange grid
     if src_data_type == 'intensive':
-        exchange_iweights = exchange_heights / dst_heights_mapped
+        exchange_iweights = old_div(exchange_heights, dst_heights_mapped)
     elif src_data_type == 'extensive':
-        exchange_iweights = exchange_heights / src_heights_mapped
+        exchange_iweights = old_div(exchange_heights, src_heights_mapped)
     else:
         raise ValueError("invalid source data type: {}"
                          .format(src_data_type))
@@ -1247,7 +1256,7 @@ def regrid_conservative_vertical(src_cube, dst_grid_cube,
     valid_heights = np.where(np.isnan(exchange_data), np.nan, exchange_heights)
     overlap_heights = np.nansum((valid_heights[np.newaxis, :] * levels_mask),
                                 axis=1)
-    overlap_heights_relative = overlap_heights / dst_heights
+    overlap_heights_relative = old_div(overlap_heights, dst_heights)
     nan_indices = np.nonzero(overlap_heights_relative < overlap_tol)
     dst_data[nan_indices] = np.nan
 

--- a/pygchem/tools/irisutil.py
+++ b/pygchem/tools/irisutil.py
@@ -22,7 +22,6 @@ from builtins import range
 from past.utils import old_div
 import collections
 import warnings
-from types import StringTypes
 
 import numpy as np
 import biggus
@@ -41,6 +40,10 @@ from pygchem.io import bpch
 from pygchem.tools import ctm2cf, timeutil
 from pygchem.utils import exceptions
 
+try:
+    basstring
+except NameError:
+    basestring = str
 
 
 # -----------------------------------------------------------------------------
@@ -488,7 +491,8 @@ def coord_from_grid(ctm_grid, coord=('longitude', 'latitude', 'levels'),
     vcoord_names = ('levels', 'sigma', 'eta', 'pressure', 'altitude')
     valid_coord_names = vcoord_names + ('longitude', 'latitude')
 
-    if isinstance(coord, StringTypes):
+
+    if isinstance(coord, basestring):
         coord = [coord]
     for c in coord:
         if c not in valid_coord_names:

--- a/pygchem/tools/timeutil.py
+++ b/pygchem/tools/timeutil.py
@@ -10,7 +10,19 @@
 Miscellaneous routine(s) for time iterations and conversions.
 
 """
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import zip
+from builtins import str
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import datetime
 
 from dateutil import rrule
@@ -51,7 +63,7 @@ def time2tau(time, reference=CTM_TIME_REF_DT):
     Convert a datetime object into given hours since reference
     (default: 01.01.1985 00:00).
     """
-    return (time - reference).total_seconds() / 3600.0
+    return old_div((time - reference).total_seconds(), 3600.0)
 
 
 def strp_relativedelta(delta_t):
@@ -64,7 +76,7 @@ def strp_relativedelta(delta_t):
     keys = 'years', 'months', 'days', 'hours', 'minutes', 'seconds'
     vals = [int(i) for i in d.split('-')] + [int(i) for i in t.split(':')]
 
-    return relativedelta(**dict(zip(keys, vals)))
+    return relativedelta(**dict(list(zip(keys, vals))))
 
 
 class DatetimeSlicer(object):
@@ -158,7 +170,7 @@ class DatetimeSlicer(object):
                 except ValueError:
                     min_max = [int(v) for v in val.split(cls._str_range_sep)]
                     min_max[1] += 1
-                    dt_elem.extend(range(*min_max))
+                    dt_elem.extend(list(range(*min_max)))
             args.append(dt_elem)
         return args
 

--- a/pygchem/utils/__init__.py
+++ b/pygchem/utils/__init__.py
@@ -11,3 +11,11 @@ Utility functions and classes that are used in PyGChem, but which are usually
 of no interest to users.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *

--- a/pygchem/utils/check_tools.py
+++ b/pygchem/utils/check_tools.py
@@ -11,7 +11,18 @@
 """
 Module that defines functions for checking various things
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import zip
+from builtins import range
+from past.builtins import basestring
+from builtins import object
 import collections
 
 
@@ -137,24 +148,24 @@ def check_fromref(check, ref, raise_error=True, traceback=[]):
     if isinstance(check, dict):
         # check a dictionary with user defined keys but values of
         # the same type (if ref is a dictionary with a unique key 'anykey')
-        if 'anykey' in ref.keys():
-            lcheck = check.values()
-            lref = ref.values() * len(lcheck)
-            lname = ["key-param '%s'" % k for k in check.keys()]
+        if 'anykey' in list(ref.keys()):
+            lcheck = list(check.values())
+            lref = list(ref.values()) * len(lcheck)
+            lname = ["key-param '%s'" % k for k in list(check.keys())]
         # otherwise, check the keys 
         else:
-            for k in ref.keys():
-                if k not in check.keys():
+            for k in list(ref.keys()):
+                if k not in list(check.keys()):
                     if raise_error:
                         raise ValueError("missing key '%s' in dictionary" % k)
                     check_passes = False
                     break
-            lcheck = [check[k] for k in ref.keys()]
-            lref = ref.values()
-            lname = ["key-param '%s'" % k for k in ref.keys()]
+            lcheck = [check[k] for k in list(ref.keys())]
+            lref = list(ref.values())
+            lname = ["key-param '%s'" % k for k in list(ref.keys())]
     # otherwise: build sequences    
     else:
-        lname = ['index %i' % i for i in xrange(0, len(check))]
+        lname = ['index %i' % i for i in range(0, len(check))]
         lcheck = check
         lref = ref
         if len(lref) < len(lcheck):

--- a/pygchem/utils/custom_decorators.py
+++ b/pygchem/utils/custom_decorators.py
@@ -13,7 +13,15 @@ Module that defines customized decorators
 
 Authors: Gribouillis
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
 from functools import partial
 
 class mixedmethod(object):

--- a/pygchem/utils/data_structures.py
+++ b/pygchem/utils/data_structures.py
@@ -11,7 +11,19 @@ Custom, generic data structures.
 
 """
 from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
 
+from builtins import *
+from future import standard_library
+standard_library.install_aliases()
+from builtins import map
+from builtins import str
+from builtins import zip
+from builtins import filter
+from builtins import range
+from builtins import object
 import sys
 import os
 import collections
@@ -21,7 +33,7 @@ from keyword import iskeyword
 from collections import OrderedDict
 from collections import Counter
 try:
-    from UserList import UserList
+    from collections import UserList
 except ImportError:
     from collections import UserList
 
@@ -242,13 +254,11 @@ class RecordList(UserList):
         selection = self.data
         for a in args:
             if not callable(a):
-                selection = filter(lambda obj: getattr(obj, self.key_attr) == a,
-                                   selection)
+                selection = [obj for obj in selection if getattr(obj, self.key_attr) == a]
             else:
-                selection = filter(a, selection)
-        for attr_name, attr_val in kwargs.items():
-            selection = filter(lambda obj: getattr(obj, attr_name) == attr_val,
-                               selection)
+                selection = list(filter(a, selection))
+        for attr_name, attr_val in list(kwargs.items()):
+            selection = [obj for obj in selection if getattr(obj, attr_name) == attr_val]
         return self._create_selection(selection)
 
     def select_one(self, *args, **kwargs):
@@ -306,9 +316,9 @@ class RecordList(UserList):
     def to_dict(self, ordered=False):
         """Return a (ordered) dictionary (`key_attr`: item) from this object."""
         if ordered:
-            return OrderedDict(zip(self.keys, self.data))
+            return OrderedDict(list(zip(self.keys, self.data)))
         else:
-            return dict(zip(self.keys, self.data))
+            return dict(list(zip(self.keys, self.data)))
 
     def insert(self, i, item):
         self._check_before_add(item)
@@ -474,8 +484,8 @@ class Record(object):
 
     def to_dict(self, ordered=False):
         """Return a new dict which maps field names to their values."""
-        kv_pairs = zip(self._properties,
-                       (getattr(self, k) for k in self._properties))
+        kv_pairs = list(zip(self._properties,
+                       (getattr(self, k) for k in self._properties)))
         if ordered:
             return OrderedDict(kv_pairs)
         else:
@@ -489,7 +499,7 @@ class Record(object):
         return len(self._properties)
 
     def __iter__(self):
-        return self.values()
+        return list(self.values())
 
     def __getitem__(self, key):
         return getattr(self, key)
@@ -516,7 +526,7 @@ class Record(object):
         vals = [getattr(self, k) for k in self._properties]
         vals2 = [v if not isinstance(v, RecordList) else repr(v)
                  for v in vals]
-        kv_pairs = zip(self._properties, vals2)
+        kv_pairs = list(zip(self._properties, vals2))
         kv_repr = ', '.join("{0}={1}".format(k, v) for k, v in kv_pairs)
         return "({0})".format(kv_repr)
 
@@ -555,7 +565,7 @@ def record_cls(cls_name, cls_description, fields, required_fields=(),
     # Taken and modified from this recipe:
     # http://code.activestate.com/recipes/576555-records/ (MIT License)
     tfield = ('name', 'type', 'default', 'read_only', 'description')
-    fields = tuple((dict(zip(tfield, f)) for f in fields))
+    fields = tuple((dict(list(zip(tfield, f))) for f in fields))
     for f in fields:
         if f['type'] == str:
             f['default'] = "'{0}'".format(f['default'])
@@ -586,7 +596,7 @@ def record_cls(cls_name, cls_description, fields, required_fields=(),
         if name.startswith('_'):
             raise ValueError("Class name and field names cannot start with an "
                              "underscore: {0}".format(name))
-    for name, count in Counter(field_names).items():
+    for name, count in list(Counter(field_names).items()):
         if count > 1:
             raise ValueError("Encountered duplicate field name: {0}"
                              .format(name))

--- a/pygchem/utils/data_structures.py
+++ b/pygchem/utils/data_structures.py
@@ -10,6 +10,7 @@
 Custom, generic data structures.
 
 """
+from __future__ import print_function
 
 import sys
 import os
@@ -661,11 +662,11 @@ def record_cls(cls_name, cls_description, fields, required_fields=(),
     # Execute the class string in a temporary namespace
     namespace = {}
     try:
-        exec "from pygchem.utils.data_structures import Record" in namespace
-        exec class_str in namespace
+        exec("from pygchem.utils.data_structures import Record", namespace)
+        exec(class_str, namespace)
         if verbose:
             print(class_str)
-    except SyntaxError, e:
+    except SyntaxError as e:
         raise SyntaxError(e.message + ':\n' + class_str)
     cls = namespace[cls_name]
     #cls.__init__.im_func.func_defaults = init_defaults

--- a/pygchem/utils/exceptions.py
+++ b/pygchem/utils/exceptions.py
@@ -10,7 +10,14 @@
 Exceptions specific to the PyGChem package.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import warnings
 import sys
 

--- a/pygchem/utils/fortranformat/FortranRecordReader.py
+++ b/pygchem/utils/fortranformat/FortranRecordReader.py
@@ -1,3 +1,11 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
 import sys
 IS_PYTHON3 = sys.version_info[0] >= 3
 

--- a/pygchem/utils/fortranformat/FortranRecordWriter.py
+++ b/pygchem/utils/fortranformat/FortranRecordWriter.py
@@ -1,3 +1,11 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
 import sys
 IS_PYTHON3 = sys.version_info[0] >= 3
 

--- a/pygchem/utils/fortranformat/__init__.py
+++ b/pygchem/utils/fortranformat/__init__.py
@@ -1,3 +1,10 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 __version__ = '0.2.3'
 
 import sys

--- a/pygchem/utils/fortranformat/_edit_descriptors.py
+++ b/pygchem/utils/fortranformat/_edit_descriptors.py
@@ -1,3 +1,12 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import str
+from builtins import object
 import sys
 IS_PYTHON3 = sys.version_info[0] >= 3
 

--- a/pygchem/utils/fortranformat/_exceptions.py
+++ b/pygchem/utils/fortranformat/_exceptions.py
@@ -1,3 +1,10 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 class InvalidFormat(Exception):
     pass

--- a/pygchem/utils/fortranformat/_input.py
+++ b/pygchem/utils/fortranformat/_input.py
@@ -1,3 +1,12 @@
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import next
+from past.utils import old_div
 import re
 import pdb
 import sys
@@ -345,8 +354,8 @@ def read_float(ed, state, record):
             return (None, state)
     # Special cases: insert a decimal if none specified
     if ('.' not in teststr) and (ed.decimal_places is not None):
-        val = val / 10 ** ed.decimal_places
+        val = old_div(val, 10 ** ed.decimal_places)
     # Apply scale factor if exponent not supplied
     if 'E' not in teststr:
-        val = val / 10 ** state['scale'] 
+        val = old_div(val, 10 ** state['scale']) 
     return (val, state)

--- a/pygchem/utils/fortranformat/_input.py
+++ b/pygchem/utils/fortranformat/_input.py
@@ -227,7 +227,7 @@ def _next(it, default=None):
         if IS_PYTHON3:
             val = next(it)
         else:
-            val = it.next()
+            val = next(it)
     except StopIteration:
         val = default
     return val

--- a/pygchem/utils/fortranformat/_lexer.py
+++ b/pygchem/utils/fortranformat/_lexer.py
@@ -1,3 +1,12 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import str
+from builtins import object
 import sys
 IS_PYTHON3 = sys.version_info[0] >= 3
 

--- a/pygchem/utils/fortranformat/_misc.py
+++ b/pygchem/utils/fortranformat/_misc.py
@@ -21,7 +21,7 @@ class has_next_iterator(object):
       if IS_PYTHON3:
         result = next(self.it)
       else:
-        result = self.it.next()
+        result = next(self.it)
     self._has_next = None
     return result
   def next(self):
@@ -31,7 +31,7 @@ class has_next_iterator(object):
       if IS_PYTHON3:
         result = next(self.it)
       else:
-        result = self.it.next()
+        result = next(self.it)
     self._has_next = None
     return result
   def has_next(self):
@@ -40,7 +40,7 @@ class has_next_iterator(object):
         if IS_PYTHON3:
           self._the_next = next(self.it)
         else:
-          self._the_next = self.it.next()
+          self._the_next = next(self.it)
       except StopIteration: self._has_next = False
       else: self._has_next = True
     return self._has_next

--- a/pygchem/utils/fortranformat/_misc.py
+++ b/pygchem/utils/fortranformat/_misc.py
@@ -1,6 +1,15 @@
 '''
 Miscellaneous functions, classes etc
 '''
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import next
+from builtins import object
 import sys
 IS_PYTHON3 = sys.version_info[0] >= 3
 
@@ -24,7 +33,7 @@ class has_next_iterator(object):
         result = next(self.it)
     self._has_next = None
     return result
-  def next(self):
+  def __next__(self):
     if self._has_next:
       result = self._the_next
     else:

--- a/pygchem/utils/fortranformat/_output.py
+++ b/pygchem/utils/fortranformat/_output.py
@@ -60,7 +60,7 @@ def output(eds, reversion_eds, values):
             if IS_PYTHON3:
                 ed = next(get_ed)
             else:
-                ed = get_ed.next()
+                ed = next(get_ed)
         else:
             if reversion_contains_output_ed == True:
                 # take from reversion edit descriptors if there is a value
@@ -87,7 +87,7 @@ def output(eds, reversion_eds, values):
                 if IS_PYTHON3:
                     val = next(get_value)
                 else:
-                    val = get_value.next()
+                    val = next(get_value)
             else:
                 # is a edit descriptor that requires a value but no value
                 # todo: does it stop gracefully or raise error?

--- a/pygchem/utils/fortranformat/_output.py
+++ b/pygchem/utils/fortranformat/_output.py
@@ -1,3 +1,13 @@
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import next
+from builtins import str
+from past.utils import old_div
 import math
 import itertools
 import sys
@@ -287,7 +297,7 @@ def _compose_float_string(w, e, d, state, val, ftype):
         nb = 0
         save_scale_factor = state['scale']
         exp_d = 10 ** d
-        if (0.0 < tmp < (0.1 - 0.05 / exp_d)) or \
+        if (0.0 < tmp < (0.1 - old_div(0.05, exp_d))) or \
             (tmp >= (exp_d - 0.5)):
             ftype = 'E'
         elif tmp == 0.0:

--- a/pygchem/utils/fortranformat/_parser.py
+++ b/pygchem/utils/fortranformat/_parser.py
@@ -105,7 +105,7 @@ def _expand_parens(tokens):
                     if IS_PYTHON3:
                         t1 = next(get_tokens)
                     else:
-                        t1 = get_tokens.next()
+                        t1 = next(get_tokens)
                 except StopIteration:
                     raise InvalidFormat('Open parens in format')
                 if t1.type == 'LEFT_PARENS':

--- a/pygchem/utils/fortranformat/_parser.py
+++ b/pygchem/utils/fortranformat/_parser.py
@@ -1,3 +1,12 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import str
+from builtins import next
 import sys
 IS_PYTHON3 = sys.version_info[0] >= 3
 

--- a/pygchem/utils/fortranformat/config.py
+++ b/pygchem/utils/fortranformat/config.py
@@ -1,3 +1,10 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import sys
 
 # Should all edit descriptor values be returned even if they were not

--- a/pygchem/utils/fortranformat/config.py
+++ b/pygchem/utils/fortranformat/config.py
@@ -17,7 +17,7 @@ ALLOW_ZERO_WIDTH_EDS = True
 if sys.version_info[0] >= 3:
     PROC_MAXINT = sys.maxsize
 else:
-    PROC_MAXINT = sys.maxint
+    PROC_MAXINT = sys.maxsize
 # Processor dependant default for including leading plus or not
 PROC_INCL_PLUS = False 
 # Option to allow signed binary, octal and hex on input (not a FORTRAN feature)
@@ -45,7 +45,7 @@ def reset():
     if sys.version_info[0] >= 3:
         PROC_MAXINT = sys.maxsize
     else:
-        PROC_MAXINT = sys.maxint
+        PROC_MAXINT = sys.maxsize
     RET_WRITTEN_VARS_ONLY = False
     RET_UNWRITTEN_VARS_NONE = True
     PROC_INCL_PLUS = False

--- a/pygchem/utils/numpyutil.py
+++ b/pygchem/utils/numpyutil.py
@@ -12,7 +12,15 @@
 """
 Miscellaneous routine(s) based on the numpy package
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import range
 import numpy as np
 
 
@@ -25,6 +33,6 @@ def broadcast_1d_array(arr, ndim, axis=1):
     different axes on a multidimensional grid.
     """
     ext_arr = arr
-    for i in xrange(ndim - 1):
+    for i in range(ndim - 1):
         ext_arr = np.expand_dims(ext_arr, axis=axis)
     return ext_arr

--- a/pygchem/utils/tff.py
+++ b/pygchem/utils/tff.py
@@ -10,7 +10,14 @@
 Basic functions for reading / writing formatted (Fortran) text files.
 
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from pygchem.utils.exceptions import NotYetImplementedError
 
 

--- a/pygchem/utils/uff.py
+++ b/pygchem/utils/uff.py
@@ -24,15 +24,16 @@ from builtins import str
 from past.builtins import basestring
 from past.utils import old_div
 import struct
+import io
 
 
 _FIX_ERROR = ("Pre- and suffix of line do not match. This can happen, if the"
               " `endian` is incorrect.")
 
 
-class FortranFile(file):
+class FortranFile(io.FileIO):
     """
-    A class for reading and writing unformatted binary Fortran files. 
+    A class for reading and writing unformatted binary Fortran files.
 
     Parameters
     ----------
@@ -57,7 +58,7 @@ class FortranFile(file):
     way as reading "real lines" in a text file. A format can be given,
     while reading or writing to pack or unpack data into a binary
     format, using the 'struct' module from the Python standard library.
-    
+
     See Documentation of Python's struct module for details on endians and
     format strings: https://docs.python.org/library/struct.html
     """

--- a/pygchem/utils/uff.py
+++ b/pygchem/utils/uff.py
@@ -11,7 +11,18 @@
 Read / write unformatted binary Fortran files.
 
 """
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import zip
+from builtins import str
+from past.builtins import basestring
+from past.utils import old_div
 import struct
 
 
@@ -170,7 +181,7 @@ def _replace_star(fmt, size):
     if n_stars:
         i = fmt.find('*')
         s = struct.calcsize(fmt.replace(fmt[i:i + 2], ''))
-        n = (size - s) / struct.calcsize(fmt[i + 1])
+        n = old_div((size - s), struct.calcsize(fmt[i + 1]))
 
         fmt = fmt.replace('*', str(n))
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def get_package_data(name, extlist):
             #    and os.path.splitext(fname)[1] in extlist):
             #    flist.append(os.path.join(dirpath, fname)[offset:])
             flist.append(os.path.join(dirpath, fname)[offset:])
-    print "Data files to install: %s" % ", ".join(flist)
+    print("Data files to install: %s" % ", ".join(flist))
     return flist
 
 
@@ -37,7 +37,7 @@ def get_subpackages(name):
                 continue
         if os.path.isfile(os.path.join(dirpath, '__init__.py')):
             splist.append(".".join(dirpath.split(os.sep)))
-    print "Packages and subpackages to install: %s" % ", ".join(splist)
+    print("Packages and subpackages to install: %s" % ", ".join(splist))
     return splist
 
 


### PR DESCRIPTION
**WORK IN PROGRESS!!**

*these are dev notes while I work on this, but I welcome pulls/reviews/comments*

I thought it would be nice to go ahead and open a Pull Request documenting some of this work. I mostly built off the scaffolding already available for reading data BPCH files into blobs (`BPCHDataProxy`), and tied it up in such a way that it was fast to skim/parse a file, and data loading could be deferred until necessary.

This works fine with some basic datasets. Datasets with multiple *lev* coordinates aren't yet supported (easy enough to do so) and there's a litany of features to implement, in particular reading the GEOS grids with more metadata attached to them. 

The biggest issue is that using the available infrastructure is extremely inefficient when it comes to loading the files; basically, the entire file needs to be read into memory before data can be accessed. One way I'm getting around this is to use the `NDArrayMixin` from xarray, which lets you slice into `BPCHDataProxy`s... but still eagerly loads the data. I added a **load_memmap** method to `BPCHDataProxy` which hooks into dask to get around this, and it's fantastic - I can read a ~2 GB BPCH file nearly instantly, and do operations on just the slices and subsets of data that I need.

A long-term solution would be to write an interface to the *entire BPCH file* instead of building chunks. The reason for this is that the output in the BPCH file are not contiguous; different timesteps are saved in different places. I need to build some more scaffolding to manage this; my naive approach works, but again eager loading kills performance since you end up having to read the entire dataset to construct the array that you want. Storing each memmapped array separately in a given `BPCHDataProxy` instance might get around this, with the help of some fancy logic **__getitem__**. Really, anything that bypasses  reading all the data at once will work.